### PR TITLE
Default player configuration

### DIFF
--- a/docs/source/connecting_to_showdown_and_challenging_humans.rst
+++ b/docs/source/connecting_to_showdown_and_challenging_humans.rst
@@ -1,0 +1,72 @@
+.. _connecting_to_showdown_and_challenging_humans:
+
+Connecting to showdown and challenging humans
+=============================================
+
+The corresponding complete source code can be found `here <https://github.com/hsahovic/poke-env/blob/master/examples/connecting_an_agent_to_showdown.py>`__.
+
+The goal of this example is to demonstrate how to run an agent on showdown, and how to challenge human players.
+
+Connecting your agent to showdown
+*********************************
+
+To connect an agent to a showdown server hosted online, you must specify a matching server configuration.
+
+A configuration pointing towards `play.pokemonshowdown.com <https://play.pokemonshowdown.com/>`__ is available in ``poke_env.server_configuration`` and can be used directly. To specify a different server, see :ref:`configuring a showdown server`.
+
+To connect to `play.pokemonshowdown.com <https://play.pokemonshowdown.com/>`__, you also need an account for your agent to use. The following snippets assumes that the account ``bot_username`` exists, and can be accessed with ``bot_password``.
+
+.. code-block:: python
+
+    from poke_env.player.random_player import RandomPlayer
+    from poke_env.player_configuration import PlayerConfiguration
+    from poke_env.server_configuration import ShowdownServerConfiguration
+
+    # We create a random player
+    player = RandomPlayer(
+        player_configuration=PlayerConfiguration("bot_username", "bot_password"),
+        server_configuration=ShowdownServerConfiguration,
+    )
+
+Challenging a human player
+**************************
+
+Now that your agent is configured to access showdown, you can use it to challenge any specific user connected on showdown. To do so, you just need their username. The following snippet will make your agent challenge user ``your_username`` for one battle.
+
+.. code-block:: python
+
+    await player.send_challenges("your_username", n_challenges=1)
+
+Alternatively, you can also use ``accept_challenges`` to automatically accept the challenges from a player. To do so, run:
+
+.. code-block:: python
+
+    # Replace opp_username with None to accept challenges from any player
+    await player.accept_challenges('opp_username', 1)
+
+Alternatively, you can also use ``accept_challenges`` and ``send_challenges`` locally, either to test your agents yourself or to create custom battle schedules.
+
+The complete source code is:
+
+.. code-block:: python
+
+    # -*- coding: utf-8 -*-
+    import asyncio
+
+    from poke_env.player.random_player import RandomPlayer
+    from poke_env.player_configuration import PlayerConfiguration
+    from poke_env.server_configuration import ShowdownServerConfiguration
+
+
+    async def main():
+        # We create a random player
+        player = RandomPlayer(
+            player_configuration=PlayerConfiguration("keop998", "aaaaaa"),
+            server_configuration=ShowdownServerConfiguration,
+        )
+        # await player.send_challenges("your_username", n_challenges=1)
+        await player.accept_challenges(None, 1)
+
+
+    if __name__ == "__main__":
+        asyncio.get_event_loop().run_until_complete(main())

--- a/docs/source/cross_evaluate_random_players.rst
+++ b/docs/source/cross_evaluate_random_players.rst
@@ -15,7 +15,7 @@ The goal of this example is to demonstrate how to run existing agents locally, a
 Getting *something* to run
 **************************
 
-``poke-env`` uses ``asyncio`` for concurrency: most of the function used to run ``poke-env`` code are async functions. Using asyncio is therefore recommended.
+``poke-env`` uses ``asyncio`` for concurrency: most of the functions used to run ``poke-env`` code are async functions. Using asyncio is therefore required.
 
 Let's start by defining a ``main`` and some boilerplate code to run it with ``asyncio``:
 
@@ -34,11 +34,11 @@ Let's start by defining a ``main`` and some boilerplate code to run it with ``as
 Creating random players
 ***********************
 
-We can now create three players. Players (or agents) are the instances that control the decisions taken in battle: here, we create ``RandomPlayer``s, which take decisions randomly. By default, ``Player`` instances will automatically use a generated username and try to connect to a local server.
+We can start by creating three players. Players (or agents) are the objects that control the decisions taken in battle: here, we create ``RandomPlayer`` s, which take decisions randomly. By default, ``Player`` instances will automatically use a generated username and try to connect to a showdown server hosted locally.
 
-You can modify this behavior by using the ``player_configuration`` and ``server_configuration`` parameters of the ``Player`` constructor.
+You can modify this behavior by using the ``player_configuration`` and ``server_configuration`` parameters of the constructor of ``Player`` objects, during initialization.
 
-Additionally, these players will play the ``gen8randombattle`` formats, which is the default battle format of ``Player`` instances: we do not need to specify it explicitly.
+By default, players play the ``gen8randombattle`` format. You can specify another battle format by passing a ``battle_format`` parameter. If you choose to play a format that requires teams, you'll also need to define it with the ``team`` parameter. You can refer to :ref:`ou_max_player` for an example using a custom team and format.
 
 .. code-block:: python
 
@@ -46,23 +46,21 @@ Additionally, these players will play the ``gen8randombattle`` formats, which is
     async def main():
         # We create three random players
         players = [
-            RandomPlayer(
-                max_concurrent_battles=10,
-            ) for _ in range(3)
+            RandomPlayer(max_concurrent_battles=10) for _ in range(3)
         ]
 
     ...
 
-.. Note::
-This example supposes that you use a local showdown server that does not require authentication.
+
+.. Note:: This example supposes that you use a local showdown server that does not require authentication.
 
 
-These players will play battles in the ``gen8randombattle`` battle format, connect to a local server, and play up to 10 battles simultaneously.
+These players will play battles in the ``gen8randombattle`` battle format, connect to a locally hosted server, and play up to 10 battles simultaneously.
 
 Cross evaluating players
 ************************
 
-Now that our players are defined, we can evaluate them: every player will play 20 games against every other player (for a total of 60 battles).
+Now that our players are defined, we can evaluate them: every player will play 20 games against every other player, for a total of 60 battles.
 
 To do so, we can use the helper function ``cross_evaluate``:
 

--- a/docs/source/cross_evaluate_random_players.rst
+++ b/docs/source/cross_evaluate_random_players.rst
@@ -30,55 +30,32 @@ Let's start by defining a ``main`` and some boilerplate code to run it with ``as
     if __name__ == "__main__":
         asyncio.get_event_loop().run_until_complete(main())
 
-Creating player configurations
-******************************
-
-Now that we can run our ``main`` function, let's create three player configurations. For each configuration, we define a username, and leave the password field to ``None``. This means that authentication will be skipped: this only works on versions of showdown configured to skip it, such as the recommended fork. If you want to run this code on `play.pokemonshowdown.com <https://play.pokemonshowdown.com/>`__, you will need to enter valid usernames and passwords.
-
-.. code-block:: python
-
-    ...
-    from poke_env.player_configuration import PlayerConfiguration
-
-    async def main():
-        player_1_configuration = PlayerConfiguration("Player 1", None)
-        player_2_configuration = PlayerConfiguration("Player 2", None)
-        player_3_configuration = PlayerConfiguration("Player 3", None)
-
-    ...
-
-.. Note::
-    This example suppose that you use a local showdown server that does not require authentication.
-
 
 Creating random players
 ***********************
 
-Now that we have our player configurations, we can create the corresponding players. Players (or agents) are the instances that control the decisions taken in battle: here, we create ``RandomPlayer``s, which take decisions randomly.
+We can now create three players. Players (or agents) are the instances that control the decisions taken in battle: here, we create ``RandomPlayer``s, which take decisions randomly. By default, ``Player`` instances will automatically use a generated username and try to connect to a local server.
+
+You can modify this behavior by using the ``player_configuration`` and ``server_configuration`` parameters of the ``Player`` constructor.
+
+Additionally, these players will play the ``gen8randombattle`` formats, which is the default battle format of ``Player`` instances: we do not need to specify it explicitly.
 
 .. code-block:: python
 
     ...
-    from poke_env.server_configuration import LocalhostServerConfiguration
-
     async def main():
-        ...
-        # We create the corresponding players.
+        # We create three random players
         players = [
             RandomPlayer(
-                player_configuration=player_config,
-                battle_format="gen8randombattle",
-                server_configuration=LocalhostServerConfiguration,
                 max_concurrent_battles=10,
-            )
-            for player_config in [
-                player_1_configuration,
-                player_2_configuration,
-                player_3_configuration,
-            ]
+            ) for _ in range(3)
         ]
 
     ...
+
+.. Note::
+This example supposes that you use a local showdown server that does not require authentication.
+
 
 These players will play battles in the ``gen8randombattle`` battle format, connect to a local server, and play up to 10 battles simultaneously.
 
@@ -125,12 +102,12 @@ Running the `whole file <https://github.com/hsahovic/poke-env/blob/master/exampl
 
 .. code-block:: python
 
-    --------  --------  --------  --------
-    -         Player 1  Player 2  Player 3
-    Player 1            0.6       0.5
-    Player 2  0.4                 0.35
-    Player 3  0.5       0.65
-    --------  --------  --------  --------
+    --------------  --------------  --------------  --------------
+    -               RandomPlayer 1  RandomPlayer 2  RandomPlayer 3
+    RandomPlayer 1                  0.53            0.52
+    RandomPlayer 2  0.47                            0.5
+    RandomPlayer 3  0.48            0.5
+    --------------  --------------  --------------  --------------
 
 If you want to create a custom player, take a look at the :ref:`max_damage_player` example.
 

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -3,7 +3,7 @@
 Examples
 ========
 
-This page lists detailled examples using this package.
+This page lists detailled examples demonstrating how to use this package. They are meant to cover basic use cases.
 
 .. toctree::
     :maxdepth: 4
@@ -13,3 +13,4 @@ This page lists detailled examples using this package.
     rl_with_open_ai_gym_wrapper
     ou_max_player
     using_custom_teambuilder
+    connecting_to_showdown_and_challenging_humans

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -9,15 +9,15 @@ This sections will guide you in installing ``poke-env`` and configuring a suited
 Installing ``poke-env``
 =======================
 
-``poke-env`` requires python >= 3.6 to be installed. It has a number of dependencies that are listed `here <https://github.com/hsahovic/poke-env/blob/master/requirements.txt>`__ and that will be installed automatically, including `numpy <https://numpy.org/>`__.
+``poke-env`` requires python >= 3.6 to be installed. It has a number of dependencies that are listed `here <https://github.com/hsahovic/poke-env/blob/master/requirements.txt>`__ and that will be installed automatically.
 
-Installation can be performed via pip with:
+Installation can be performed via pip:
 
 .. code-block:: bash
 
     pip install poke-env
 
-.. note:: Although the module does not support python 3.5, this can be worked around by replacing `aiologger` imports by `logger` imports. This will however affect performance. If this is an issue for your use case, please `open an issue <https://github.com/hsahovic/poke-env/issues>`__.
+.. _configuring a showdown server:
 
 Configuring a showdown server
 =============================
@@ -57,12 +57,27 @@ You should then get something like this:
 
 If that is the case, congratulations! You just launched your server! You can now refer to :ref:`examples` to create your first agent.
 
+
+Creating agents
+===============
+
+In ``poke-env``, agents are represented by instances of python classes inheriting from ``Player``. This class incorporates everything that is needed to communicate with showdown servers, as well as many utilities designed to make creating agents easier.
+
+To get started on creating an agent, we recommended taking a look at explained examples.
+
+- Running agent: :ref:`cross_evaluate_random_players`
+- Creating a first non-trivial agent: :ref:`max_damage_player`
+- Using Reinforcement Learning to train an agent: :ref:`rl_with_open_ai_gym_wrapper`
+- Using teams and managing team preview in non-random formats: :ref:`ou_max_player`
+- Building a custom teambuilder: :ref:`using_custom_teambuilder`
+
+
 Configuring showdown players
 ============================
 
-``Player`` instances require a ``player_configuration`` argument, which must be of type ``PlayerConfiguration``.
+``Player`` instances need a player configuration corresponding to showdown accounts. By default, such configurations are automatically generated for each ``Player``. These automatically generated configurations are compatible with servers bypassing authentication, such as the recommended fork mentionned above.
 
-``PlayerConfiguration`` are named tuples with two arguments: an username and a password.
+You can create custom configurations, for instance to use existing showdown accounts. To do so, use the ``player_configuration`` argument of ``Player`` constructors: you can pass in a ``PlayerConfiguration``, which are named tuples with two arguments: an username and a password.
 
 Users without authentication
 ----------------------------
@@ -93,15 +108,15 @@ If your showdown configuration uses authentication, the values of each ``player_
 Connecting your bots to showdown
 ================================
 
-``Player`` instances require a ``server_configuration`` argument, which must be of type ``ServerConfiguration``.
+``Player`` instances need a server configuration pointing to a websocket endpoint and an authentication endpoint. By default, ``Player`` instances will use ``LocalhostServerConfiguration``, which corresponds to the default configuration of local showdown servers.
 
-``ServerConfiguration`` are named tuples with two arguments: a server url and an authentication endpoint url.
+You can set custom configurations by using the ``server_configuration`` argument of ``Player`` instances. It expects a ``ServerConfiguration`` object, which is a named tuple containing a server url and authentication url.
 
 ``poke-env`` includes two ready-to-use ``ServerConfiguration`` objects: ``LocalhostServerConfiguration`` and ``ShowdownServerConfiguration``.
 
-The first one points to ``locahost:8000`` (the default endpoint for a local showdown server), whereas the second one points to ``https://play.pokemonshowdown.com/``. Both use the same authentication endpoint, https://play.pokemonshowdown.com/action.php?.
+The first one points to ``locahost:8000`` - the default endpoint for a local showdown server - whereas the second one points to ``https://play.pokemonshowdown.com/``. Both use the same authentication endpoint, https://play.pokemonshowdown.com/action.php?.
 
-If you use our custom fork of showdown, as mentionned in Getting Started, players do not need to authenticate to battle. This effectively skips authentication calls to the authentication endpoint: your agents can access your server without an internet connection.
+If you use our custom fork of showdown, as mentionned in Getting Started, players do not need to authenticate to battle. This effectively skips authentication calls: your agents can access your server without an internet connection.
 
 Custom server configuration
 ===========================
@@ -120,16 +135,3 @@ You can create your own server configuration if you want to connect your player 
     )
 
     # You can now use my_server_config with a Player object
-
-Creating agents
-===============
-
-In ``poke-env``, agents are represented by instances of python classes inheriting from ``Player``. This class incorporates everything that is needed to communicate with showdown servers, as well as many utilities designed to make creating agents easier.
-
-To get started on creating agent, we recommended taking a look at explained examples.
-
-- Running agent: :ref:`cross_evaluate_random_players`
-- Creating a first non-trivial agent: :ref:`max_damage_player`
-- Using Reinforcement Learning to train an agent: :ref:`rl_with_open_ai_gym_wrapper`
-- Using teams and managing team preview in non-random formats: :ref:`ou_max_player`
-- Building a custom teambuilder: :ref:`using_custom_teambuilder`

--- a/docs/source/max_damage_player.rst
+++ b/docs/source/max_damage_player.rst
@@ -28,7 +28,7 @@ Let's create the base class:
     class MaxDamagePlayer(Player):
         pass
 
-``Player``'s ``choose_move`` method is abstract: it needs to be implemented if we want to instantiate our player. It is the only method that we have to define to be able to use the agent.
+``Player``'s has one abstract method, ``choose_move``. Once implemented, we will be able to instantiate and use our player.
 
 Creating a ``choose_move`` method
 *********************************
@@ -36,14 +36,14 @@ Creating a ``choose_move`` method
 Method signature
 ****************
 
-The signature of ``choose_move`` is ``choose_move(self, battle: Battle) -> str``.
+The signature of ``choose_move`` is ``choose_move(self, battle: Battle) -> str``: it takes a ``Battle`` object representing the game state as argument, and returns a move order encoded as a string. This move order must be formatted according to the `showdown protocol <https://github.com/smogon/pokemon-showdown/blob/master/sim/SIM-PROTOCOL.md>`__. Fortunately, ``poke-env`` provides utility functions allowing us to directly format such orders from ``Pokemon`` and ``Move`` objects.
 
 We therefore have to take care of two things: first, reading the information we need from the ``battle`` parameter. Then, we have to return a properly formatted response, corresponding to our move order.
 
 Selecting a move
 ****************
 
-The ``battle`` parameter is an object of type ``Battle`` representing the agent's current knowledge of the game state. It offers several properties that make accessing the game state easy. Some of the most notable are ``active_pokemon``, ``available_moves``, ``available_switches``, ``opponent_active_pokemon``, ``opponent_team`` and ``team``.
+The ``battle`` parameter is an object of type ``Battle`` which encodes the agent's current knowledge of the game state. It offers several properties that make accessing the game state easy. Some of the most notable are ``active_pokemon``, ``available_moves``, ``available_switches``, ``opponent_active_pokemon``, ``opponent_team`` and ``team``.
 
 In this example, we are going to use ``available_moves``: it returns a list of ``Move`` objects which are available this turn.
 
@@ -63,7 +63,7 @@ Returning a choice
 
 Now that we have selected a move, we need to return a corresponding order, which takes the form of a string. Fortunately, ``Player`` provides a method designed to craft such strings directly: ``create_order``. It takes a ``Pokemon`` (for switches) or ``Move`` object as argument, and returns a string corresponding to the order. Additionally, you can use its ``mega``, ``z_move`` and ``dynamax`` parameters to mega evolve, use a z-move, dynamax or gigantamax, if possible this turn.
 
-We also have to return an order corresponding to a random switch if the player can not attack. ``Player`` objects incorporate a ``choose_random_move`` method, which we will use if no attacking move is available.
+We also have to return an order corresponding to a random switch if the player cannot attack. ``Player`` objects incorporate a ``choose_random_move`` method, which we will use if no attacking move is available.
 
 .. code-block:: python
 
@@ -82,7 +82,7 @@ We also have to return an order corresponding to a random switch if the player c
 Running and testing our agent
 *****************************
 
-We can now test our agent by crossing evaluating with a random agent. The final code is:
+We can now test our agent by crossing evaluating it with a random agent. The complete code is:
 
 .. code-block:: python
 

--- a/docs/source/max_damage_player.rst
+++ b/docs/source/max_damage_player.rst
@@ -93,8 +93,6 @@ We can now test our agent by crossing evaluating with a random agent. The final 
     from poke_env.player.player import Player
     from poke_env.player.random_player import RandomPlayer
     from poke_env.player.utils import cross_evaluate
-    from poke_env.player_configuration import PlayerConfiguration
-    from poke_env.server_configuration import LocalhostServerConfiguration
 
 
     class MaxDamagePlayer(Player):
@@ -113,20 +111,12 @@ We can now test our agent by crossing evaluating with a random agent. The final 
     async def main():
         start = time.time()
 
-        # We define two player configurations.
-        player_1_configuration = PlayerConfiguration("Random player", None)
-        player_2_configuration = PlayerConfiguration("Max damage player", None)
-
-        # We create the corresponding players.
+        # We create two players.
         random_player = RandomPlayer(
-            player_configuration=player_1_configuration,
             battle_format="gen8randombattle",
-            server_configuration=LocalhostServerConfiguration,
         )
         max_damage_player = MaxDamagePlayer(
-            player_configuration=player_2_configuration,
             battle_format="gen8randombattle",
-            server_configuration=LocalhostServerConfiguration,
         )
 
         # Now, let's evaluate our player

--- a/docs/source/ou_max_player.rst
+++ b/docs/source/ou_max_player.rst
@@ -39,7 +39,9 @@ You can access your team with ``Battle.team`` and your opponent's team with ``Ba
 
 The order of the keys in ``Battle.team`` is the same as the order that showdown is considering: if you want to lead with the second pokemon in your team, returning ``/team 213456`` would work.
 
-Here, we are going to evaluate how good of a lead each pokemon we have is, and return the one we deem to be best. To do that, we are going to need an evaluation function:
+Here, we are going to evaluate how good of a lead each pokemon we have is, and return the one we deem to be best. To do that, we are going to need an evaluation function.
+
+We define it as follows: we evaluate the performance of a pokemon against another one as the difference between the effectiveness of the first pokemon and the second's pokemon types. Here is an implementation:
 
 .. code-block:: python
 
@@ -56,7 +58,7 @@ Here, we are going to evaluate how good of a lead each pokemon we have is, and r
         # Our performance metric is the different between the two
         return a_on_b - b_on_a
 
-We define a simple performance evaluation function: the difference between effectiveness of our pokemon and the opponent's pokemon types. We can now create a teampreview method:
+We can now use it in our ``teampreview`` method:
 
 .. code-block:: python
 
@@ -80,7 +82,6 @@ We define a simple performance evaluation function: the difference between effec
         return "/team " + ''.join([str(i + 1) for i in ordered_mons])
 
 This method sends our pokemons ordered by their average estimated performance against the opponent team.
-
 
 Specifying a team
 *****************

--- a/docs/source/ou_max_player.rst
+++ b/docs/source/ou_max_player.rst
@@ -282,22 +282,15 @@ To attribute a team to an agent, you need to pass a ``team`` argument to the age
     - Rock Blast
     - Tail Slap
     """
-    # We define two player configurations.
-    player_1_configuration = PlayerConfiguration("Random player", None)
-    player_2_configuration = PlayerConfiguration("Max damage player", None)
 
-    # We create the corresponding players.
+    # We create two players.
     random_player = RandomPlayer(
-        player_configuration=player_1_configuration,
         battle_format="gen8ou",
-        server_configuration=LocalhostServerConfiguration,
         team=team_1,
         max_concurrent_battles=10,
     )
     max_damage_player = MaxDamagePlayer(
-        player_configuration=player_2_configuration,
         battle_format="gen8ou",
-        server_configuration=LocalhostServerConfiguration,
         team=team_2,
         max_concurrent_battles=10,
     )
@@ -320,8 +313,6 @@ We can now test our agent by crossing evaluating it with a random agent. The com
     from poke_env.player.player import Player
     from poke_env.player.random_player import RandomPlayer
     from poke_env.player.utils import cross_evaluate
-    from poke_env.player_configuration import PlayerConfiguration
-    from poke_env.server_configuration import LocalhostServerConfiguration
 
 
     class MaxDamagePlayer(Player):
@@ -488,22 +479,14 @@ We can now test our agent by crossing evaluating it with a random agent. The com
     - Tail Slap
     """
 
-    # We define two player configurations.
-    player_1_configuration = PlayerConfiguration("Random player", None)
-    player_2_configuration = PlayerConfiguration("Max damage player", None)
-
-    # We create the corresponding players.
+    # We create two players.
     random_player = RandomPlayer(
-        player_configuration=player_1_configuration,
         battle_format="gen8ou",
-        server_configuration=LocalhostServerConfiguration,
         team=team_1,
         max_concurrent_battles=10,
     )
     max_damage_player = MaxDamagePlayer(
-        player_configuration=player_2_configuration,
         battle_format="gen8ou",
-        server_configuration=LocalhostServerConfiguration,
         team=team_2,
         max_concurrent_battles=10,
     )

--- a/docs/source/rl_with_open_ai_gym_wrapper.rst
+++ b/docs/source/rl_with_open_ai_gym_wrapper.rst
@@ -98,14 +98,7 @@ Now that our custom class is defined, we can instantiate a player.
 .. code-block:: python
 
     ...
-    from poke_env.player_configuration import PlayerConfiguration
-    from poke_env.server_configuration import LocalhostServerConfiguration
-
-    env_player = SimpleRLPlayer(
-        player_configuration=PlayerConfiguration("RL Player", None),
-        battle_format="gen8randombattle",
-        server_configuration=LocalhostServerConfiguration,
-    )
+    env_player = SimpleRLPlayer(battle_format="gen8randombattle")
     ...
 
 
@@ -210,11 +203,7 @@ We will create a ``dqn_training`` function. In addition to the player, it will a
         # This call will finished eventual unfinshed battles before returning
         player.complete_current_battle()
 
-    opponent = RandomPlayer(
-        player_configuration=PlayerConfiguration("Random player", None),
-        battle_format="gen8randombattle",
-        server_configuration=LocalhostServerConfiguration,
-    )
+    opponent = RandomPlayer(battle_format="gen8randombattle")
 
     # Training
     env_player.play_against(
@@ -245,11 +234,7 @@ Similarly to the training function above, we can define an evaluation function.
 
     # Ths code of MaxDamagePlayer is not reproduced for brevity and legibility
     # It can be found in the complete code linked above, or in the max damage example
-    second_opponent = MaxDamagePlayer(
-        player_configuration=PlayerConfiguration("Max damage player", None),
-        battle_format="gen8randombattle",
-        server_configuration=LocalhostServerConfiguration,
-    )
+    second_opponent = MaxDamagePlayer(battle_format="gen8randombattle")
 
     # Evaluation
     print("Results against random player:")

--- a/docs/source/rl_with_open_ai_gym_wrapper.rst
+++ b/docs/source/rl_with_open_ai_gym_wrapper.rst
@@ -12,15 +12,18 @@ The goal of this example is to demonstrate how to use the `open ai gym <https://
 
 .. note:: This example necessitates `keras-rl <https://github.com/keras-rl/keras-rl>`__ (compatible with Tensorflow 1.X) or `keras-rl2 <https://github.com/wau/keras-rl2>`__ (Tensorflow 2.X), which implement numerous reinforcement learning algorithms and offer a simple API fully compatible with the Open AI Gym API. You can install them by running ``pip install keras-rl`` or ``pip install keras-rl2``. If you are unsure, ``pip install keras-rl2`` is recommended.
 
+.. warning:: ``keras-rl2`` version 1.0.4 seems to be causing problems with this example. While we are trying to find a workaround, please try using version 1.0.3
+
+
 Implementing rewards and observations
 *************************************
 
-The open ai gym API provides *rewards* and *observations* for each step of each episode. In our case, each step corresponds to one decision in one battle and battles correspond to episodes.
+The open ai gym API provides *rewards* and *observations* for each step of each episode. In our case, each step corresponds to one decision in a battle and battles correspond to episodes.
 
 Defining observations
 ^^^^^^^^^^^^^^^^^^^^^
 
-Observations are embeddings of the current state of the battle. They can be an arbitrarily precise description of battle state, or a very simple representation. In this example, we will create embedding vectors containing:
+Observations are embeddings of the current state of the battle. They can be an arbitrarily precise description of battle states, or a very simple representation. In this example, we will create embedding vectors containing:
 
 - the base power of each available move
 - the damage multiplier of each available move against the current active opponent pokemon
@@ -37,11 +40,11 @@ Rewards are signals that the agent will use in its optimization process (a commo
 We will use this method to define the following reward:
 
 - Winning corresponds to a positive reward of 30
-- Making an opponent's pokemon faint corresponds to a positive reward
-- Making an opponent lose n% hp corresponds to a positive reward of %
+- Making an opponent's pokemon faint corresponds to a positive reward of 1
+- Making an opponent lose % hp corresponds to a positive reward of %
 - Other status conditions are ignored
 
-Conversly, symmetric actions lead to symmetric rewards: losing would make you lose 30 points, etc.
+Conversly, negative actions lead to symettrically negative rewards: losing is a reward of -30 points, etc.
 
 To define our rewards, we will create a custom ``compute_reward`` method. It takes one argument, a ``Battle`` object, and returns the reward.
 
@@ -93,7 +96,7 @@ Our player will play the ``gen8randombattle`` format. We can therefore inheritat
 Instanciating a player
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-Now that our custom class is defined, we can instantiate a player.
+Now that our custom class is defined, we can instantiate our RL player.
 
 .. code-block:: python
 
@@ -136,7 +139,7 @@ The output of the model must map to the environment's action space. The action s
 Defining the DQN
 ^^^^^^^^^^^^^^^^
 
-Now that we have a model, we can build the DQN agent. It additionally needs a *policy* and a *memory*. The *memory* is an object that will store past actions and define samples used during learning. The *policy* describes how actions are chosen during learning.
+Now that we have a model, we can build the DQN agent. This agent combines our model with a *policy* and a *memory*. The *memory* is an object that will store past actions and define samples used during learning. The *policy* describes how actions are chosen during learning.
 
 We will use a simple memory containing 10000 steps, and an epsilon greedy policy.
 
@@ -190,7 +193,7 @@ This method accepts three arguments:
 - ``opponent``: another ``Player`` that will be faced by the ``env_player``
 - ``env_algorithm_kwargs``: a dictionary containing other objects that will be passed to ``env_algorithm``
 
-We will create a ``dqn_training`` function. In addition to the player, it will accept two additional arguments: ``dqn`` and ``nb_steps``.
+To train our agent, we will create a custom ``dqn_training`` function. In addition to the player, it will accept two additional arguments: ``dqn`` and ``nb_steps``. We can pass it in a call to ``play_against`` as the ``env_algorithm`` argument.
 
 .. code-block:: python
 

--- a/docs/source/using_custom_teambuilder.rst
+++ b/docs/source/using_custom_teambuilder.rst
@@ -173,24 +173,14 @@ Our ``custom_builder`` can now be used! To use a ``Teambuilder`` with a given ``
 .. code-block:: python
 
     from poke_env.player.random_player import RandomPlayer
-    from poke_env.player_configuration import PlayerConfiguration
-    from poke_env.server_configuration import LocalhostServerConfiguration
-
-
-    player_1_configuration = PlayerConfiguration("Random player 1", None)
-    player_2_configuration = PlayerConfiguration("Random player 2", None)
 
     player_1 = RandomPlayer(
-        player_configuration=player_1_configuration,
         battle_format="gen8ou",
-        server_configuration=LocalhostServerConfiguration,
         team=custom_builder,
         max_concurrent_battles=10,
     )
     player_2 = RandomPlayer(
-        player_configuration=player_2_configuration,
         battle_format="gen8ou",
-        server_configuration=LocalhostServerConfiguration,
         team=custom_builder,
         max_concurrent_battles=10,
     )
@@ -208,15 +198,12 @@ The complete example looks like that:
 
 .. code-block:: python
 
- # -*- coding: utf-8 -*-
-
+    # -*- coding: utf-8 -*-
     import asyncio
     import numpy as np
 
     from poke_env.player.random_player import RandomPlayer
     from poke_env.player.utils import cross_evaluate
-    from poke_env.player_configuration import PlayerConfiguration
-    from poke_env.server_configuration import LocalhostServerConfiguration
     from poke_env.teambuilder.teambuilder import Teambuilder
 
 
@@ -348,23 +335,14 @@ The complete example looks like that:
 
 
     async def main():
-
-        # We define two player configurations.
-        player_1_configuration = PlayerConfiguration("Random player 1", None)
-        player_2_configuration = PlayerConfiguration("Random player 2", None)
-
-        # We create the corresponding players.
+        # We create two players
         player_1 = RandomPlayer(
-            player_configuration=player_1_configuration,
             battle_format="gen8ou",
-            server_configuration=LocalhostServerConfiguration,
             team=custom_builder,
             max_concurrent_battles=10,
         )
         player_2 = RandomPlayer(
-            player_configuration=player_2_configuration,
             battle_format="gen8ou",
-            server_configuration=LocalhostServerConfiguration,
             team=custom_builder,
             max_concurrent_battles=10,
         )

--- a/examples/connecting_an_agent_to_showdown.py
+++ b/examples/connecting_an_agent_to_showdown.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+import asyncio
+
+from poke_env.player.random_player import RandomPlayer
+from poke_env.player_configuration import PlayerConfiguration
+from poke_env.server_configuration import ShowdownServerConfiguration
+
+
+async def main():
+    # We create a random player
+    player = RandomPlayer(
+        player_configuration=PlayerConfiguration("bot_username", "bot_password"),
+        server_configuration=ShowdownServerConfiguration,
+    )
+    await player.send_challenges("your_username", n_challenges=1)
+
+
+if __name__ == "__main__":
+    asyncio.get_event_loop().run_until_complete(main())

--- a/examples/connecting_an_agent_to_showdown.py
+++ b/examples/connecting_an_agent_to_showdown.py
@@ -9,10 +9,11 @@ from poke_env.server_configuration import ShowdownServerConfiguration
 async def main():
     # We create a random player
     player = RandomPlayer(
-        player_configuration=PlayerConfiguration("bot_username", "bot_password"),
+        player_configuration=PlayerConfiguration("keop998", "aaaaaa"),
         server_configuration=ShowdownServerConfiguration,
     )
-    await player.send_challenges("your_username", n_challenges=1)
+    # await player.send_challenges("your_username", n_challenges=1)
+    await player.accept_challenges(None, 1)
 
 
 if __name__ == "__main__":

--- a/examples/cross_evaluate_random_players.py
+++ b/examples/cross_evaluate_random_players.py
@@ -3,31 +3,12 @@ import asyncio
 
 from poke_env.player.random_player import RandomPlayer
 from poke_env.player.utils import cross_evaluate
-from poke_env.player_configuration import PlayerConfiguration
-from poke_env.server_configuration import LocalhostServerConfiguration
 from tabulate import tabulate
 
 
 async def main():
-    # First, we define three player configurations.
-    player_1_configuration = PlayerConfiguration("Player 1", None)
-    player_2_configuration = PlayerConfiguration("Player 2", None)
-    player_3_configuration = PlayerConfiguration("Player 3", None)
-
-    # Then, we create the corresponding players.
-    players = [
-        RandomPlayer(
-            player_configuration=player_config,
-            battle_format="gen8randombattle",
-            server_configuration=LocalhostServerConfiguration,
-            max_concurrent_battles=10,
-        )
-        for player_config in [
-            player_1_configuration,
-            player_2_configuration,
-            player_3_configuration,
-        ]
-    ]
+    # We create three random players
+    players = [RandomPlayer(max_concurrent_battles=10) for _ in range(3)]
 
     # Now, we can cross evaluate them: every player will player 20 games against every
     # other player.

--- a/examples/custom_teambuilder.py
+++ b/examples/custom_teambuilder.py
@@ -4,8 +4,6 @@ import numpy as np
 
 from poke_env.player.random_player import RandomPlayer
 from poke_env.player.utils import cross_evaluate
-from poke_env.player_configuration import PlayerConfiguration
-from poke_env.server_configuration import LocalhostServerConfiguration
 from poke_env.teambuilder.teambuilder import Teambuilder
 
 
@@ -137,25 +135,12 @@ custom_builder = RandomTeamFromPool([team_1, team_2])
 
 
 async def main():
-
-    # We define two player configurations.
-    player_1_configuration = PlayerConfiguration("Random player 1", None)
-    player_2_configuration = PlayerConfiguration("Random player 2", None)
-
-    # We create the corresponding players.
+    # We create two players
     player_1 = RandomPlayer(
-        player_configuration=player_1_configuration,
-        battle_format="gen8ou",
-        server_configuration=LocalhostServerConfiguration,
-        team=custom_builder,
-        max_concurrent_battles=10,
+        battle_format="gen8ou", team=custom_builder, max_concurrent_battles=10
     )
     player_2 = RandomPlayer(
-        player_configuration=player_2_configuration,
-        battle_format="gen8ou",
-        server_configuration=LocalhostServerConfiguration,
-        team=custom_builder,
-        max_concurrent_battles=10,
+        battle_format="gen8ou", team=custom_builder, max_concurrent_battles=10
     )
 
     await cross_evaluate([player_1, player_2], n_challenges=5)

--- a/examples/max_damage_player.py
+++ b/examples/max_damage_player.py
@@ -5,8 +5,6 @@ import time
 from poke_env.player.player import Player
 from poke_env.player.random_player import RandomPlayer
 from poke_env.player.utils import cross_evaluate
-from poke_env.player_configuration import PlayerConfiguration
-from poke_env.server_configuration import LocalhostServerConfiguration
 
 
 class MaxDamagePlayer(Player):
@@ -25,21 +23,9 @@ class MaxDamagePlayer(Player):
 async def main():
     start = time.time()
 
-    # We define two player configurations.
-    player_1_configuration = PlayerConfiguration("Random player", None)
-    player_2_configuration = PlayerConfiguration("Max damage player", None)
-
-    # We create the corresponding players.
-    random_player = RandomPlayer(
-        player_configuration=player_1_configuration,
-        battle_format="gen8randombattle",
-        server_configuration=LocalhostServerConfiguration,
-    )
-    max_damage_player = MaxDamagePlayer(
-        player_configuration=player_2_configuration,
-        battle_format="gen8randombattle",
-        server_configuration=LocalhostServerConfiguration,
-    )
+    # We create two players.
+    random_player = RandomPlayer(battle_format="gen8randombattle")
+    max_damage_player = MaxDamagePlayer(battle_format="gen8randombattle")
 
     # Now, let's evaluate our player
     cross_evaluation = await cross_evaluate(

--- a/examples/ou_max_player.py
+++ b/examples/ou_max_player.py
@@ -5,8 +5,6 @@ import numpy as np
 from poke_env.player.player import Player
 from poke_env.player.random_player import RandomPlayer
 from poke_env.player.utils import cross_evaluate
-from poke_env.player_configuration import PlayerConfiguration
-from poke_env.server_configuration import LocalhostServerConfiguration
 
 
 class MaxDamagePlayer(Player):
@@ -173,24 +171,12 @@ Jolly Nature
 - Tail Slap
 """
 
-    # We define two player configurations.
-    player_1_configuration = PlayerConfiguration("Random player", None)
-    player_2_configuration = PlayerConfiguration("Max damage player", None)
-
-    # We create the corresponding players.
+    # We create two players.
     random_player = RandomPlayer(
-        player_configuration=player_1_configuration,
-        battle_format="gen8ou",
-        server_configuration=LocalhostServerConfiguration,
-        team=team_1,
-        max_concurrent_battles=10,
+        battle_format="gen8ou", team=team_1, max_concurrent_battles=10
     )
     max_damage_player = MaxDamagePlayer(
-        player_configuration=player_2_configuration,
-        battle_format="gen8ou",
-        server_configuration=LocalhostServerConfiguration,
-        team=team_2,
-        max_concurrent_battles=10,
+        battle_format="gen8ou", team=team_2, max_concurrent_battles=10
     )
 
     # Now, let's evaluate our player

--- a/examples/rl_with_open_ai_gym_wrapper.py
+++ b/examples/rl_with_open_ai_gym_wrapper.py
@@ -2,10 +2,8 @@
 import numpy as np
 import tensorflow as tf
 
-from poke_env.player_configuration import PlayerConfiguration
 from poke_env.player.env_player import Gen8EnvSinglePlayer
 from poke_env.player.random_player import RandomPlayer
-from poke_env.server_configuration import LocalhostServerConfiguration
 
 from rl.agents.dqn import DQNAgent
 from rl.policy import LinearAnnealedPolicy, EpsGreedyQPolicy
@@ -94,23 +92,10 @@ def dqn_evaluation(player, dqn, nb_episodes):
 
 
 if __name__ == "__main__":
-    env_player = SimpleRLPlayer(
-        player_configuration=PlayerConfiguration("RL Player", None),
-        battle_format="gen8randombattle",
-        server_configuration=LocalhostServerConfiguration,
-    )
+    env_player = SimpleRLPlayer(battle_format="gen8randombattle")
 
-    opponent = RandomPlayer(
-        player_configuration=PlayerConfiguration("Random player", None),
-        battle_format="gen8randombattle",
-        server_configuration=LocalhostServerConfiguration,
-    )
-
-    second_opponent = MaxDamagePlayer(
-        player_configuration=PlayerConfiguration("Max damage player", None),
-        battle_format="gen8randombattle",
-        server_configuration=LocalhostServerConfiguration,
-    )
+    opponent = RandomPlayer(battle_format="gen8randombattle")
+    second_opponent = MaxDamagePlayer(battle_format="gen8randombattle")
 
     # Output dimension
     n_action = len(env_player.action_space)

--- a/src/poke_env/player/env_player.py
+++ b/src/poke_env/player/env_player.py
@@ -31,26 +31,30 @@ class EnvPlayer(Player, Env, ABC):  # pyre-ignore
 
     def __init__(
         self,
-        player_configuration: PlayerConfiguration,
+        player_configuration: Optional[PlayerConfiguration] = None,
         *,
         avatar: Optional[int] = None,
-        battle_format: str,
+        battle_format: str = "gen8randombattle",
         log_level: Optional[int] = None,
-        server_configuration: ServerConfiguration,
+        server_configuration: Optional[ServerConfiguration] = None,
         start_listening: bool = True,
         team: Optional[Union[str, Teambuilder]] = None,
     ):
         """
-        :param player_configuration: Player configuration.
-        :type player_configuration: PlayerConfiguration
+        :param player_configuration: Player configuration. If empty, defaults to an
+            automatically generated username with no password. This option must be set
+            if the server configuration requires authentication.
+        :type player_configuration: PlayerConfiguration, optional
         :param avatar: Player avatar id. Optional.
         :type avatar: int, optional
-        :param battle_format: Name of the battle format this player plays.
+        :param battle_format: Name of the battle format this player plays. Defaults to
+            gen8randombattle.
         :type battle_format: str
         :param log_level: The player's logger level.
         :type log_level: int. Defaults to logging's default level.
-        :param server_configuration: Server configuration.
-        :type server_configuration: ServerConfiguration
+        :param server_configuration: Server configuration. Defaults to Localhost Server
+            Configuration.
+        :type server_configuration: ServerConfiguration, optional
         :param start_listening: Wheter to start listening to the server. Defaults to
             True.
         :type start_listening: bool

--- a/src/poke_env/player/player.py
+++ b/src/poke_env/player/player.py
@@ -23,7 +23,9 @@ from poke_env.environment.pokemon import Pokemon
 from poke_env.exceptions import ShowdownException
 from poke_env.exceptions import UnexpectedEffectException
 from poke_env.player.player_network_interface import PlayerNetwork
+from poke_env.player_configuration import _create_player_configuration_from_player
 from poke_env.player_configuration import PlayerConfiguration
+from poke_env.server_configuration import LocalhostServerConfiguration
 from poke_env.server_configuration import ServerConfiguration
 from poke_env.teambuilder.teambuilder import Teambuilder
 from poke_env.teambuilder.constant_teambuilder import ConstantTeambuilder
@@ -38,30 +40,34 @@ class Player(PlayerNetwork, ABC):
 
     def __init__(
         self,
-        player_configuration: PlayerConfiguration,
+        player_configuration: Optional[PlayerConfiguration] = None,
         *,
         avatar: Optional[int] = None,
-        battle_format: str,
+        battle_format: str = "gen8randombattle",
         log_level: Optional[int] = None,
         max_concurrent_battles: int = 1,
-        server_configuration: ServerConfiguration,
+        server_configuration: Optional[ServerConfiguration] = None,
         start_listening: bool = True,
         team: Optional[Union[str, Teambuilder]] = None,
     ) -> None:
         """
-        :param player_configuration: Player configuration.
-        :type player_configuration: PlayerConfiguration
+        :param player_configuration: Player configuration. If empty, defaults to an
+            automatically generated username with no password. This option must be set
+            if the server configuration requires authentication.
+        :type player_configuration: PlayerConfiguration, optional
         :param avatar: Player avatar id. Optional.
         :type avatar: int, optional
-        :param battle_format: Name of the battle format this player plays.
+        :param battle_format: Name of the battle format this player plays. Defaults to
+            gen8randombattle.
         :type battle_format: str
         :param log_level: The player's logger level.
         :type log_level: int. Defaults to logging's default level.
         :param max_concurrent_battles: Maximum number of battles this player will play
             concurrently. If 0, no limit will be applied. Defaults to 1.
         :type max_concurrent_battles: int
-        :param server_configuration: Server configuration.
-        :type server_configuration: ServerConfiguration
+        :param server_configuration: Server configuration. Defaults to Localhost Server
+            Configuration.
+        :type server_configuration: ServerConfiguration, optional
         :param start_listening: Wheter to start listening to the server. Defaults to
             True.
         :type start_listening: bool
@@ -70,6 +76,11 @@ class Player(PlayerNetwork, ABC):
             Defaults to None.
         :type team: str or Teambuilder, optional
         """
+        if player_configuration is None:
+            player_configuration = _create_player_configuration_from_player(self)
+
+        if server_configuration is None:
+            server_configuration = LocalhostServerConfiguration
         super(Player, self).__init__(
             player_configuration=player_configuration,
             avatar=avatar,

--- a/src/poke_env/player_configuration.py
+++ b/src/poke_env/player_configuration.py
@@ -2,7 +2,18 @@
 """This module contains objects related to player configuration.
 """
 from collections import namedtuple
+from collections import Counter
 
 PlayerConfiguration = namedtuple("PlayerConfiguration", ["username", "password"])
 """Player configuration object. Represented with a tuple with two entries: username and
 password."""
+
+_CONFIGURATION_FROM_PLAYER_COUNTER = Counter()
+
+
+def _create_player_configuration_from_player(player) -> PlayerConfiguration:
+    key = type(player).__name__
+    _CONFIGURATION_FROM_PLAYER_COUNTER.update([key])
+    return PlayerConfiguration(
+        "%s %d" % (key, _CONFIGURATION_FROM_PLAYER_COUNTER[key]), None
+    )

--- a/src/poke_env/server_configuration.py
+++ b/src/poke_env/server_configuration.py
@@ -16,6 +16,6 @@ LocalhostServerConfiguration = ServerConfiguration(
 """Server configuration with localhost and smogon's authentication endpoint."""
 
 ShowdownServerConfiguration = ServerConfiguration(
-    "https://play.pokemonshowdown.com/", "https://play.pokemonshowdown.com/action.php?"
+    "sim.smogon.com:8000", "https://play.pokemonshowdown.com/action.php?"
 )
 """Server configuration with smogon's server and authentication endpoint."""

--- a/unit_tests/player/test_player_default_configuration.py
+++ b/unit_tests/player/test_player_default_configuration.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+
+from poke_env.player.random_player import RandomPlayer
+from poke_env.player.player import Player
+from poke_env.player_configuration import _CONFIGURATION_FROM_PLAYER_COUNTER
+
+
+class CustomPlayer(Player):
+    def choose_move(self, battle):
+        return self.choose_random_move(battle)
+
+
+def test_default_player_configuration():
+    _CONFIGURATION_FROM_PLAYER_COUNTER.clear()
+
+    usernames = set()
+
+    for k in range(5):
+        for C in [CustomPlayer, RandomPlayer]:
+            instance = C()
+            username = instance.username
+            assert username not in usernames
+            usernames.add(username)
+
+            assert username
+            assert isinstance(username, str)
+
+            assert instance._password is None
+
+
+def test_default_server_configuration():
+    for k in range(5):
+        for C in [CustomPlayer, RandomPlayer]:
+            instance = C()
+            url = instance.websocket_url
+
+            assert url
+            assert isinstance(url, str)
+            assert "localhost" in url or "127.0.0.1" in url


### PR DESCRIPTION
This PR introduces default options for `Player` instances.

In particular:

- By default, the player configuration is automatically populated with a unique username designed to work on authentication-less showdown servers
- By default, the server configuration points to the default localhost server
- By default, the `Player` plays `gen8randombattles`