### PR TITLE
Added import instruction for RandomPlayer on tutorial.

### DIFF
--- a/docs/source/cross_evaluate_random_players.rst
+++ b/docs/source/cross_evaluate_random_players.rst
@@ -43,6 +43,8 @@ By default, players play the ``gen8randombattle`` format. You can specify anothe
 .. code-block:: python
 
     ...
+    from poke_env.player.random_player import RandomPlayer
+
     async def main():
         # We create three random players
         players = [


### PR DESCRIPTION
While following [this tutorial](https://poke-env.readthedocs.io/en/stable/cross_evaluate_random_players.html#creating-random-players) I stumbled upon an error telling that **RamdomPlayer** was undefined. 
Python was right  :joy:, there was no import for **RandomPlayer**.
