### PR TITLE
Hide 'MOVES_DICT'

### DIFF
--- a/docs/source/move.rst
+++ b/docs/source/move.rst
@@ -4,6 +4,7 @@ The move object
 ===============
 
 .. automodule:: poke_env.environment.move
+   :exclude-members: MOVES_DICT
    :members:
    :undoc-members:
    :show-inheritance:


### PR DESCRIPTION
Hide 'MOVES_DICT', as it makes navigating the docs very cumbersome.