### PR TITLE
Check for items & abilities when parsing damage & heal messages

### DIFF
--- a/unit_tests/environment/test_battle.py
+++ b/unit_tests/environment/test_battle.py
@@ -405,6 +405,98 @@ def test_battle_request_and_interactions(example_request):
     assert not battle.maybe_trapped
     assert battle.opponent_can_dynamax
 
+    # Items
+    battle._parse_message(
+        [
+            "",
+            "-damage",
+            "p2a: Necrozma",
+            "167/319",
+            "[from] item: Rocky Helmet",
+            "[of] p1a: Groudon",
+        ]
+    )
+    assert battle.opponent_active_pokemon.item == "rockyhelmet"
+    battle.opponent_active_pokemon._item = None
+
+    battle._parse_message(
+        [
+            "",
+            "-damage",
+            "p1a: Groudon",
+            "100/265",
+            "[from] item: Rocky Helmet",
+            "[of] p2a: Necrozma",
+        ]
+    )
+    assert battle.active_pokemon.item == "rockyhelmet"
+    battle.active_pokemon._item = None
+
+    battle._parse_message(
+        ["", "-damage", "p2a: Necrozma", "100/265", "[from] item: Life Orb"]
+    )
+    assert battle.active_pokemon.item == "lifeorb"
+    battle.active_pokemon._item = None
+
+    battle._parse_message(
+        ["", "-damage", "p1a: Groudon", "100/265", "[from] item: Life Orb"]
+    )
+    assert battle.opponent_active_pokemon.item == "lifeorb"
+    battle.opponent_active_pokemon._item = None
+
+    # Abilities
+    battle._parse_message(
+        [
+            "",
+            "-damage",
+            "p2a: Necrozma",
+            "167/319",
+            "[from] ability: Iron Barbs",
+            "[of] p1a: Groudon",
+        ]
+    )
+    assert battle.opponent_active_pokemon.ability == "ironbarbs"
+    battle.opponent_active_pokemon._ability = None
+
+    battle._parse_message(
+        [
+            "",
+            "-damage",
+            "p2a: Necrozma",
+            "100/265",
+            "[from] ability: Iron Barbs",
+            "[of] p1a: Groudon",
+        ]
+    )
+    assert battle.opponent_active_pokemon.ability == "ironbarbs"
+    battle.opponent_active_pokemon._ability = None
+
+    battle._parse_message(
+        [
+            "",
+            "-heal",
+            "p1a: Groudon",
+            "200/265",
+            "[from] ability: Water Absorb",
+            "[of] p2a: Necrozma",
+        ]
+    )
+    assert battle.opponent_active_pokemon.ability == "waterabsorb"
+    battle.opponent_active_pokemon._ability = None
+
+    battle._parse_message(
+        [
+            "",
+            "-heal",
+            "p2a: Necrozma",
+            "200/265",
+            "[from] ability: Water Absorb",
+            "[of] p1a: Groudon",
+        ]
+    )
+    assert battle.active_pokemon.ability == "waterabsorb"
+    battle.active_pokemon._ability = None
+
 
 def test_end_illusion():
     logger = MagicMock()


### PR DESCRIPTION
Hey Haris :wave: 

Been using poke-env for some personal testing and noticed some information not being parsed from the battle-log.

This PR parses and updates the battle object for

**items** from:
- the item-holder damaging the opponent (example: Rocky Helmet)

**abilities** from:
- the ability healing the pokemon to which it belongs (example: Water Absorb, Volt Absorb)
- the ability damaging the opponent's pokemon (example: Iron Barbs, Rough Skin)

I've tried to write this in a way that I think makes sense with your project - but feel free to criticize anything and everything I wrote :upside_down_face: 

Items healing the pokemon to which they belong is intentionally omitted since they may be consumed during the process (berries), but the message for consumption happens _before_ the -heal message so this would result in an incorrect state. I have a solution for this that I've used in my project but I'll leave that for another discussion/PR.