### PR TITLE
Parse messages from items healing a Pokemon

### DIFF
--- a/src/poke_env/data.py
+++ b/src/poke_env/data.py
@@ -10,6 +10,9 @@ from typing import Any, Union
 from typing import Dict
 
 
+UNKNOWN_ITEM = "unknown_item"
+
+
 def _compute_type_chart(chart_path: str) -> Dict[str, Dict[str, float]]:
     """Returns the pokemon type_chart.
 

--- a/src/poke_env/environment/pokemon.py
+++ b/src/poke_env/environment/pokemon.py
@@ -6,7 +6,7 @@ from typing import Optional
 from typing import Tuple
 from typing import Union
 
-from poke_env.data import GEN_TO_POKEDEX
+from poke_env.data import GEN_TO_POKEDEX, UNKNOWN_ITEM
 from poke_env.environment.effect import Effect
 from poke_env.environment.pokemon_gender import PokemonGender
 from poke_env.environment.pokemon_type import PokemonType
@@ -92,7 +92,7 @@ class Pokemon:
         self._current_hp: int = 0
         self._effects: Dict[Effect, int] = {}
         self._first_turn: bool = False
-        self._item: Optional[str] = None
+        self._item: Optional[str] = UNKNOWN_ITEM
         self._last_request: dict = {}
         self._last_details: str = ""
         self._must_recharge = False

--- a/unit_tests/environment/test_battle.py
+++ b/unit_tests/environment/test_battle.py
@@ -18,6 +18,7 @@ from poke_env.environment.pokemon_type import PokemonType
 from poke_env.environment.side_condition import SideCondition
 from poke_env.environment.status import Status
 from poke_env.environment.weather import Weather
+from poke_env.data import UNKNOWN_ITEM
 
 
 def test_battle_get_pokemon():
@@ -496,6 +497,26 @@ def test_battle_request_and_interactions(example_request):
     )
     assert battle.active_pokemon.ability == "waterabsorb"
     battle.active_pokemon._ability = None
+
+    battle.active_pokemon.item = UNKNOWN_ITEM
+    battle._parse_message(
+        ["", "-heal", "p2a: Necrozma", "200/265", "[from] item: Leftovers"]
+    )
+    assert battle.active_pokemon.item == "leftovers"
+    battle.active_pokemon.item = None
+
+    battle.opponent_active_pokemon.item = UNKNOWN_ITEM
+    battle._parse_message(
+        ["", "-heal", "p1a: Groudon", "200/265", "[from] item: Leftovers"]
+    )
+    assert battle.opponent_active_pokemon.item == "leftovers"
+    battle.opponent_active_pokemon.item = None
+
+    battle.opponent_active_pokemon.item = None
+    battle._parse_message(
+        ["", "-heal", "p1a: Groudon", "200/265", "[from] item: Sitrus Berry"]
+    )
+    assert battle.opponent_active_pokemon.item is None
 
 
 def test_end_illusion():


### PR DESCRIPTION
An addition to e93835abb1419bc28fb9e2f342ab563f5428ac04. This allows the
environment to parse items that heal the holder: Most notably Leftovers
and berries.

This also required an UNKNOWN_ITEM constant that each Pokemon's item
will now be initialized as, allowing the environment to distinguish between no item
(None) and an unknown item. This is necessary because the PS server will
give a log that looks like this when a berry is consumed:

```
|-damage|p2a: Blissey|22/714
|-enditem|p2a: Blissey|Sitrus Berry|[eat]
|-heal|p2a: Blissey|200/714|[from] item: Sitrus Berry
```

In the above log, the berry has already been consumed, but the heal
statement comes afterwards. The item will be None in this situation
because the `-enditem` log will have set it to None.

Making UNKNOWN_ITEM a string constant seemed logical, but whatever you think is appropriate is fine.