### PR TITLE
Fix deepcopy recursion

### DIFF
--- a/src/poke_env/environment/move.py
+++ b/src/poke_env/environment/move.py
@@ -801,6 +801,8 @@ class DynamaxMove(Move):
         self._parent: Move = parent
 
     def __getattr__(self, name):
+        if name[:2] == '__':
+            raise AttributeError(name)
         return getattr(self._parent, name)
 
     @property


### PR DESCRIPTION
Allows to deepcopy the battle object avoiding '\_\_setstate\_\_' hook from copy library to create a loop as self._parent is not initialised. This allows to study history-aware solutions.