### PR TITLE
Fix real player leaving match

### DIFF
--- a/src/poke_env/environment/abstract_battle.py
+++ b/src/poke_env/environment/abstract_battle.py
@@ -133,7 +133,7 @@ class AbstractBattle(ABC):
         self._teampreview: bool = False
         self._teampreview_opponent_team: Set[Pokemon] = set()
         self._anybody_inactive: bool = False
-        self._reconnected = True
+        self._reconnected: bool = True
         self.logger: Logger = logger
 
         # Turn choice attributes


### PR DESCRIPTION
When laddering, a real player could disconnect. This would cause the server to send another "player" message without rating and avatar, causing the parser to crash. This will fix the issue and allow a more consistent laddering experience.

Here's a battle where the player left. Without this fix, the parser would raise a ValueError.
[player leaving.txt](https://github.com/hsahovic/poke-env/files/7999237/player.leaving.txt)