### PR TITLE
Fix real player leaving match

### DIFF
--- a/src/poke_env/environment/abstract_battle.py
+++ b/src/poke_env/environment/abstract_battle.py
@@ -640,10 +640,10 @@ class AbstractBattle(ABC):
             self._in_team_preview = True
         elif split_message[1] == "gen":
             self._format = split_message[2]
-        elif split_message[1] == 'inactive':
-            if 'disconnected' in split_message[2]:
+        elif split_message[1] == "inactive":
+            if "disconnected" in split_message[2]:
                 self._anybody_inactive = True
-            elif 'reconnected' in split_message[2]:
+            elif "reconnected" in split_message[2]:
                 self._anybody_inactive = False
                 self._reconnected = True
         elif split_message[1] == "player":

--- a/src/poke_env/environment/abstract_battle.py
+++ b/src/poke_env/environment/abstract_battle.py
@@ -133,7 +133,7 @@ class AbstractBattle(ABC):
         self._teampreview: bool = False
         self._teampreview_opponent_team: Set[Pokemon] = set()
         self._anybody_inactive: bool = False
-        self._reconnected = True
+        self._reconnected: bool = True
         self.logger: Logger = logger
 
         # Turn choice attributes

--- a/src/poke_env/environment/abstract_battle.py
+++ b/src/poke_env/environment/abstract_battle.py
@@ -654,7 +654,7 @@ class AbstractBattle(ABC):
                     if self._reconnected:
                         self._reconnected = False
                     else:
-                        raise RuntimeError(f"Invalid player message")
+                        raise RuntimeError("Invalid player message")
                 return
             if username == self._player_username:
                 self._player_role = player

--- a/src/poke_env/environment/abstract_battle.py
+++ b/src/poke_env/environment/abstract_battle.py
@@ -647,14 +647,14 @@ class AbstractBattle(ABC):
                 self._anybody_inactive = False
                 self._reconnected = True
         elif split_message[1] == "player":
-            try:
+            if len(split_message) == 6:
                 player, username, avatar, rating = split_message[2:6]
-            except ValueError as e:
+            else:
                 if not self._anybody_inactive:
                     if self._reconnected:
                         self._reconnected = False
                     else:
-                        raise e
+                        raise RuntimeError(f"Invalid player message")
                 return
             if username == self._player_username:
                 self._player_role = player

--- a/src/poke_env/environment/move.py
+++ b/src/poke_env/environment/move.py
@@ -801,7 +801,7 @@ class DynamaxMove(Move):
         self._parent: Move = parent
 
     def __getattr__(self, name):
-        if name[:2] == '__':
+        if name[:2] == "__":
             raise AttributeError(name)
         return getattr(self._parent, name)
 


### PR DESCRIPTION
When laddering, a real player could disconnect. This would cause the server to send another "player" message without rating and avatar, causing the parser to crash. This will fix the issue and allow a more consistent laddering experience.

Here's a battle where the player left. Without this fix, the parser would raise a ValueError.
[player.leaving.txt](https://github.com/hsahovic/poke-env/files/8011149/player.leaving.txt)
