### PR TITLE
Added support for Minimize as an Effect

### DIFF
--- a/src/poke_env/environment/abstract_battle.py
+++ b/src/poke_env/environment/abstract_battle.py
@@ -477,10 +477,11 @@ class AbstractBattle(ABC):
                     self.turn,
                 )
 
-            #Check if a silent-effect move has occurred (Minimize) and add the effect
-            if move.upper() == "MINIMIZE":
-                pokemon = self.get_pokemon(pokemon)
-                pokemon._start_effect("MINIMIZE")
+            # Check if a silent-effect move has occurred (Minimize) and add the effect
+
+            if move.upper().strip() == "MINIMIZE":
+                temp_pokemon = self.get_pokemon(pokemon)
+                temp_pokemon._start_effect("MINIMIZE")
 
             if override_move:
                 self.get_pokemon(pokemon)._moved(override_move, failed=failed)

--- a/src/poke_env/environment/abstract_battle.py
+++ b/src/poke_env/environment/abstract_battle.py
@@ -477,6 +477,11 @@ class AbstractBattle(ABC):
                     self.turn,
                 )
 
+            #Check if a silent-effect move has occurred (Minimize) and add the effect
+            if move.upper() == "MINIMIZE":
+                pokemon = self.get_pokemon(pokemon)
+                pokemon._start_effect("MINIMIZE")
+
             if override_move:
                 self.get_pokemon(pokemon)._moved(override_move, failed=failed)
             if override_move is None or reveal_other_move:

--- a/src/poke_env/environment/effect.py
+++ b/src/poke_env/environment/effect.py
@@ -94,6 +94,7 @@ class Effect(Enum):
     MIMIC = auto()
     MIMICRY = auto()
     MIND_READER = auto()
+    MINIMIZE = auto()
     MIRACLE_EYE = auto()
     MIST = auto()
     MISTY_TERRAIN = auto()


### PR DESCRIPTION
Minimize is a silent effect that causes increased damage from certain moves https://bulbapedia.bulbagarden.net/wiki/Minimize_(move)

I opened an issue https://github.com/hsahovic/poke-env/issues/251 asking about this feature, but went ahead and added support for this specific move myself.

Let me know if there are any changes that should be made to this commit to get it approved