### PR TITLE
Add more memory to CircleCI container

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,9 @@ jobs:
       # use `-browsers` prefix for selenium tests, e.g. `3.6.1-browsers`
       - image: cimg/python:3.6.14-node
 
+    #Using medium+ to avoid RAM shortage during integration tests
+    resource_class: medium+
+
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images
       # documented at https://circleci.com/docs/2.0/circleci-images/


### PR DESCRIPTION
Hey @hsahovic,
would it be possible to use a medium+ container instead of a medium one?
This way we could guarantee that integration tests won't get killed by CircleCI because it has no more RAM.
Right now this is a bet as the logs get saved in RAM so long battles take up a lot of it and failure depends on the battle length, not the code.
Let me know