### PR TITLE
Keep n_hit return type consistent across all move subclasses

### DIFF
--- a/src/poke_env/environment/move.py
+++ b/src/poke_env/environment/move.py
@@ -892,7 +892,7 @@ class DynamaxMove(Move):
 
     @property
     def n_hit(self):
-        return 1
+        return 1, 1
 
     @property
     def priority(self):

--- a/unit_tests/environment/test_move.py
+++ b/unit_tests/environment/test_move.py
@@ -629,7 +629,7 @@ def test_misc_dynamax_move_properties():
     assert dynamaxed.heal == 0
     assert dynamaxed.is_protect_counter is False
     assert dynamaxed.is_protect_move is False
-    assert dynamaxed.n_hit == 1
+    assert dynamaxed.n_hit == (1, 1)
     assert dynamaxed.priority == 0
     assert dynamaxed.recoil == 0
     assert dynamaxed.status is None
@@ -654,7 +654,7 @@ def test_dynamax_status_move_properties():
     assert dynamaxed.heal == 0
     assert dynamaxed.is_protect_counter is True
     assert dynamaxed.is_protect_move is True
-    assert dynamaxed.n_hit == 1
+    assert dynamaxed.n_hit == (1, 1)
     assert dynamaxed.priority == 0
     assert dynamaxed.recoil == 0
     assert dynamaxed.status is None


### PR DESCRIPTION
Dynamaxed moves should return a tuple to be consistent with the move base class.