### PR TITLE
Fix updateuser check to include `@!` suffix

### DIFF
--- a/src/poke_env/player/player_network_interface.py
+++ b/src/poke_env/player/player_network_interface.py
@@ -155,7 +155,10 @@ class PlayerNetwork(ABC):
                 # Confirms connection to the server: we can login
                 await self._log_in(split_messages[0])
             elif split_messages[0][1] == "updateuser":
-                if split_messages[0][2] == " " + self._username:
+                if split_messages[0][2] in [
+                    " " + self._username,
+                    " " + self._username + "@!",
+                ]:
                     # Confirms successful login
                     self.logged_in.set()
                 elif not split_messages[0][2].startswith(" Guest "):


### PR DESCRIPTION
If a player is considered inactive (or busy but this should not be the case), its username will be suffixed with `@!`. This will account for that.