### PR TITLE
Add ping interval and timeout to player

### DIFF
--- a/src/poke_env/player/env_player.py
+++ b/src/poke_env/player/env_player.py
@@ -34,6 +34,8 @@ class EnvPlayer(OpenAIGymEnv, ABC):
         server_configuration: Optional[ServerConfiguration] = None,
         start_listening: bool = True,
         start_timer_on_battle_start: bool = False,
+        ping_interval: Optional[float] = 20.0,
+        ping_timeout: Optional[float] = 20.0,
         team: Optional[Union[str, Teambuilder]] = None,
         start_challenging: bool = True,
     ):
@@ -65,6 +67,14 @@ class EnvPlayer(OpenAIGymEnv, ABC):
         :param start_timer_on_battle_start: Whether to automatically start the battle
             timer on battle start. Defaults to False.
         :type start_timer_on_battle_start: bool
+        :param ping_interval: How long between keepalive pings (Important for backend
+            websockets). If None, disables keepalive entirely.
+        :type ping_interval: float, optional
+        :param ping_timeout: How long to wait for a timeout of a specific ping
+            (important for backend websockets.
+            Increase only if timeouts occur during runtime).
+            If None pings will never time out.
+        :type ping_timeout: float, optional
         :param team: The team to use for formats requiring a team. Can be a showdown
             team string, a showdown packed team string, of a ShowdownTeam object.
             Defaults to None.
@@ -91,6 +101,8 @@ class EnvPlayer(OpenAIGymEnv, ABC):
             start_listening=start_listening,
             start_timer_on_battle_start=start_timer_on_battle_start,
             team=team,
+            ping_interval=ping_interval,
+            ping_timeout=ping_timeout,
             start_challenging=start_challenging,
         )
 

--- a/src/poke_env/player/openai_api.py
+++ b/src/poke_env/player/openai_api.py
@@ -113,6 +113,8 @@ class OpenAIGymEnv(Env, ABC):  # pyre-ignore
         ] = LocalhostServerConfiguration,
         start_timer_on_battle_start: bool = False,
         start_listening: bool = True,
+        ping_interval: Optional[float] = 20.0,
+        ping_timeout: Optional[float] = 20.0,
         team: Optional[Union[str, Teambuilder]] = None,
         start_challenging: bool = False,
     ):
@@ -142,6 +144,14 @@ class OpenAIGymEnv(Env, ABC):  # pyre-ignore
         :param start_timer_on_battle_start: Whether to automatically start the battle
             timer on battle start. Defaults to False.
         :type start_timer_on_battle_start: bool
+        :param ping_interval: How long between keepalive pings (Important for backend
+            websockets). If None, disables keepalive entirely.
+        :type ping_interval: float, optional
+        :param ping_timeout: How long to wait for a timeout of a specific ping
+            (important for backend websockets.
+            Increase only if timeouts occur during runtime).
+            If None pings will never time out.
+        :type ping_timeout: float, optional
         :param team: The team to use for formats requiring a team. Can be a showdown
             team string, a showdown packed team string, of a ShowdownTeam object.
             Defaults to None.
@@ -162,6 +172,8 @@ class OpenAIGymEnv(Env, ABC):  # pyre-ignore
             server_configuration=server_configuration,
             start_timer_on_battle_start=start_timer_on_battle_start,
             start_listening=start_listening,
+            ping_interval=ping_interval,
+            ping_timeout=ping_timeout,
             team=team,
         )
         self.battle_format = battle_format

--- a/src/poke_env/player/player.py
+++ b/src/poke_env/player/player.py
@@ -64,6 +64,8 @@ class Player(PlayerNetwork, ABC):
         server_configuration: Optional[ServerConfiguration] = None,
         start_timer_on_battle_start: bool = False,
         start_listening: bool = True,
+        ping_interval: Optional[float] = 20.0,
+        ping_timeout: Optional[float] = 20.0,
         team: Optional[Union[str, Teambuilder]] = None,
     ) -> None:
         """
@@ -91,6 +93,14 @@ class Player(PlayerNetwork, ABC):
         :param start_listening: Whether to start listening to the server. Defaults to
             True.
         :type start_listening: bool
+        :param ping_interval: How long between keepalive pings (Important for backend
+            websockets). If None, disables keepalive entirely.
+        :type ping_interval: float, optional
+        :param ping_timeout: How long to wait for a timeout of a specific ping
+            (important for backend websockets.
+            Increase only if timeouts occur during runtime).
+            If None pings will never time out.
+        :type ping_timeout: float, optional
         :param start_timer_on_battle_start: Whether to automatically start the battle
             timer on battle start. Defaults to False.
         :type start_timer_on_battle_start: bool
@@ -111,6 +121,8 @@ class Player(PlayerNetwork, ABC):
             log_level=log_level,
             server_configuration=server_configuration,
             start_listening=start_listening,
+            ping_interval=ping_interval,
+            ping_timeout=ping_timeout,
         )
 
         self._format: str = battle_format


### PR DESCRIPTION
Sometimes showdown server could suffer from a lag spike, expecially on less powerful machines. This allows to increase or disable timeouts for the keepalive mechanism used by websockets.

@hsahovic let me know if you think this could be useful