### PR TITLE
Account for get_event_loop() deprecation warning in Python 3.10

### DIFF
--- a/src/poke_env/player/player_network_interface.py
+++ b/src/poke_env/player/player_network_interface.py
@@ -75,7 +75,16 @@ class PlayerNetwork(ABC):
 
     @staticmethod
     def _create_class(cls, *args, **kwargs):  # pragma: no cover
-        if asyncio.get_event_loop() == POKE_LOOP:
+        try:
+            # Python >= 3.7
+            loop = asyncio.get_running_loop()
+        except AttributeError:
+            # Python < 3.7 so get_event_loop won't raise exceptions
+            loop = asyncio.get_event_loop()
+        except RuntimeError:
+            # asyncio.get_running_loop raised exception so no loop is running
+            loop = None
+        if loop == POKE_LOOP:
             return cls(*args, **kwargs)
         else:
             return asyncio.run_coroutine_threadsafe(


### PR DESCRIPTION
Account for future deprecation of get_event_loop method of asyncio. get_running_loop is threadsafe so the effect will be the same