### PR TITLE
Fix allyswitch on same turn as faint issue

### DIFF
--- a/src/poke_env/environment/double_battle.py
+++ b/src/poke_env/environment/double_battle.py
@@ -143,6 +143,33 @@ class DoubleBattle(AbstractBattle):
                         self._active_pokemon[f"{self.player_role}a"] = active_pokemon
                     elif f"{self.player_role}b" not in self._active_pokemon:
                         self._active_pokemon[f"{self.player_role}b"] = active_pokemon
+                    elif (
+                        active_pokemon_number == 0
+                        and self._active_pokemon[f"{self.player_role}a"].fainted
+                        and self._active_pokemon[f"{self.player_role}b"]
+                        == active_pokemon
+                    ):
+                        (
+                            self._active_pokemon[f"{self.player_role}a"],
+                            self._active_pokemon[f"{self.player_role}b"],
+                        ) = (
+                            self._active_pokemon[f"{self.player_role}b"],
+                            self._active_pokemon[f"{self.player_role}a"],
+                        )
+                    elif (
+                        active_pokemon_number == 1
+                        and self._active_pokemon[f"{self.player_role}b"].fainted
+                        and not active_pokemon.fainted
+                        and self._active_pokemon[f"{self.player_role}a"]
+                        == active_pokemon
+                    ):
+                        (
+                            self._active_pokemon[f"{self.player_role}a"],
+                            self._active_pokemon[f"{self.player_role}b"],
+                        ) = (
+                            self._active_pokemon[f"{self.player_role}b"],
+                            self._active_pokemon[f"{self.player_role}a"],
+                        )
 
                 if active_pokemon.fainted:
                     continue
@@ -193,7 +220,7 @@ class DoubleBattle(AbstractBattle):
 
     def _swap(self, pokemon_str: str, slot: str):
         player_identifier = pokemon_str.split(":")[0][:2]
-        team = (
+        active = (
             self._active_pokemon
             if player_identifier == self.player_role
             else self._opponent_active_pokemon
@@ -201,11 +228,11 @@ class DoubleBattle(AbstractBattle):
         slot_a = f"{player_identifier}a"
         slot_b = f"{player_identifier}b"
 
-        if team[slot_a].fainted or team[slot_b].fainted:
+        if active[slot_a].fainted or active[slot_b].fainted:
             return
 
-        slot_a_mon = team[slot_a]
-        slot_b_mon = team[slot_b]
+        slot_a_mon = active[slot_a]
+        slot_b_mon = active[slot_b]
 
         pokemon = self.get_pokemon(pokemon_str)
 
@@ -214,7 +241,7 @@ class DoubleBattle(AbstractBattle):
         ):
             pass
         else:
-            team[slot_a], team[slot_b] = team[slot_b], team[slot_a]
+            active[slot_a], active[slot_b] = active[slot_b], active[slot_a]
 
     def get_possible_showdown_targets(
         self, move: Move, pokemon: Pokemon, dynamax: bool = False

--- a/src/poke_env/environment/pokemon.py
+++ b/src/poke_env/environment/pokemon.py
@@ -578,6 +578,17 @@ class Pokemon:
         return []
 
     @property
+    def base_species(self) -> str:
+        """
+        :return: The pokemon's base species.
+        :rtype: str
+        """
+        dex_entry = self._data.pokedex[self._species]
+        if "baseSpecies" in dex_entry:
+            return to_id_str(dex_entry["baseSpecies"])
+        return self._species
+
+    @property
     def base_stats(self) -> Dict[str, int]:
         """
         :return: The pokemon's base stats.

--- a/unit_tests/environment/test_pokemon.py
+++ b/unit_tests/environment/test_pokemon.py
@@ -150,3 +150,19 @@ def test_pokemon_boosts():
     mon.clear_negative_boosts()
     assert mon.boosts["accuracy"] == 0
     assert mon.boosts["spd"] == 2
+
+
+def test_pokemon_base_species():
+    charizard = Pokemon(species="charizard", gen=8)
+    mega_charizard_x = Pokemon(species="charizardmegax", gen=8)
+    mega_charizard_y = Pokemon(species="charizardmegay", gen=8)
+
+    assert charizard.base_species == "charizard"
+    assert mega_charizard_x.base_species == "charizard"
+    assert mega_charizard_y.base_species == "charizard"
+
+    arceus = Pokemon(species="arceus", gen=8)
+    acreus_bug = Pokemon(species="arceusbug", gen=8)
+
+    assert arceus.base_species == "arceus"
+    assert acreus_bug.base_species == "arceus"


### PR DESCRIPTION
Fix https://github.com/hsahovic/poke-env/issues/437

We usually receive request messages before parsing the events of a turn. This leads to the status of pokemon being updated before actually receiving the corresponding individual messages. Because the `_swap` method that allyswitch messages call in battle objects checks whether a pokemon is fainted before switching their place, if a pokemon uses alyswitch before it or its partner faint later in the turn, we can erroneously not switch their place.

This PR adds a check in double message request parsing: if the faint status and species of mons do not match, we force-switch them.

Additionally, to make the check more robust to form changes, this PR adds a `base_species` property to `Pokemon` objects.