### PR TITLE
Misc. Gen 1 Compatability Issues

### DIFF
--- a/src/poke_env/data/static/moves/gen1moves.json
+++ b/src/poke_env/data/static/moves/gen1moves.json
@@ -211,7 +211,7 @@
         "priority": 0,
         "secondary": null,
         "target": "self",
-        "type": "???",
+        "type": "Normal",
         "volatileStatus": "bide"
     },
     "bind": {
@@ -2447,7 +2447,7 @@
             "metronome": 1,
             "snatch": 1
         },
-        "heal": null,
+        "heal": [1, 2],
         "name": "Recover",
         "num": 105,
         "onHit": "onHit",
@@ -2983,7 +2983,7 @@
             "metronome": 1,
             "snatch": 1
         },
-        "heal": null,
+        "heal": [1, 2],
         "name": "Soft-Boiled",
         "num": 135,
         "onHit": "onHit",

--- a/src/poke_env/environment/move.py
+++ b/src/poke_env/environment/move.py
@@ -110,9 +110,12 @@ class Move:
 
     @staticmethod
     def is_id_z(id_: str, gen: int) -> bool:
-        if id_.startswith("z") and id_[1:] in GenData.from_gen(gen).moves:
+        move_data = GenData.from_gen(gen).moves
+        if id_.startswith("z") and id_[1:] in move_data:
             return True
-        return "isZ" in GenData.from_gen(gen).moves[id_]
+        elif id_ in move_data:
+            return "isZ" in move_data[id_]
+        return False
 
     @staticmethod
     def is_max_move(id_: str, gen: int) -> bool:
@@ -296,7 +299,7 @@ class Move:
         elif self._id.startswith("z") and self._id[1:] in self._moves_dict:
             return self._moves_dict[self._id[1:]]
         elif self._id == "recharge":
-            return {"pp": 1, "type": "normal", "category": "Special", "accuracy": 1}
+            return {"pp": 1, "type": "normal", "category": "Special", "priority" : 0, "target" : "self", "accuracy": 1}
         else:
             raise ValueError("Unknown move: %s" % self._id)
 
@@ -768,7 +771,6 @@ class Move:
         elif base_power <= 130:
             return 195
         return 200
-
 
 class EmptyMove(Move):
     def __init__(self, move_id: str):


### PR DESCRIPTION
It seems like Gen 1 compatibility isn't a huge focus, but by creating matchups between random `Player` baselines from ~1k gen1ou teams I've encountered a few issues which seem fixable.

1. Healing moves in gen1 throw an error on `move.heal` because they try to divide by None

https://github.com/hsahovic/poke-env/blob/46fa2b012d30d43ad7dbb0d2d1ed2a8ef521e528/src/poke_env/environment/move.py#L347-L355

In gen1 the move data has heal entries but set their value to `null`, while later generations set it to a list that becomes the heal fraction:

https://github.com/hsahovic/poke-env/blob/46fa2b012d30d43ad7dbb0d2d1ed2a8ef521e528/src/poke_env/data/static/moves/gen1moves.json#L2976-L2997

https://github.com/hsahovic/poke-env/blob/46fa2b012d30d43ad7dbb0d2d1ed2a8ef521e528/src/poke_env/data/static/moves/gen8moves.json#L16808-L16832

Is this intentional, or would it be correct to copy the `heal` entries from later generations into the `gen1moves.json`?

2. In gen1, Light Screen gets routed to the `Effect` enum, which causes it to become `Effect.UNKNOWN`, while it's treated as a known `SideCondition` in other generations. The difference seems to be that the showdown `split_message` in later gens is `['-sidestart', ..., 'move: Light Screen']` while in gen1 it is `['-start', ..., 'Light Screen']`.

`WARNING - Unexpected effect 'LIGHT_SCREEN' received. Effect.UNKNOWN will be used instead. If this is unexpected, please open an issue`

https://github.com/hsahovic/poke-env/blob/46fa2b012d30d43ad7dbb0d2d1ed2a8ef521e528/src/poke_env/environment/abstract_battle.py#L538-L541

https://github.com/hsahovic/poke-env/blob/46fa2b012d30d43ad7dbb0d2d1ed2a8ef521e528/src/poke_env/environment/abstract_battle.py#L643-L645

3. `HAZE` also becomes a Effect.UNKNOWN, but I'm not sure whether it's supposed to be an Effect or a SideCondition

4. The `recharge` placeholder isn't in any of the move jsons, so it doesn't have entries for things like `priority`. There's a special case for this but it could probably use some more default entries:

https://github.com/hsahovic/poke-env/blob/46fa2b012d30d43ad7dbb0d2d1ed2a8ef521e528/src/poke_env/environment/move.py#L298-L299

Seems to be a similar issue when checking `is_id_z`, which only comes up when playing gen1 with players written for any generation.

5. Gens 2, 3, and 4 have the ??? type, and there's a special `THREE_QUESTION_MARKS` type for this. But `bide` is listed as ??? type in gen1. It's also a physical move, so when we go to get its `category` we try to map it to the physical/special type split and `THREE_QUESTION_MARKS` isn't in there. Seems like we can just set it's type to `Normal`?

https://github.com/hsahovic/poke-env/blob/46fa2b012d30d43ad7dbb0d2d1ed2a8ef521e528/src/poke_env/data/static/moves/gen1moves.json#L211-L216


https://github.com/hsahovic/poke-env/blob/46fa2b012d30d43ad7dbb0d2d1ed2a8ef521e528/src/poke_env/environment/move.py#L193-L201

6. I get a ton of message parsing warnings similar to: `WARNING - Unmanaged move message format received - cleaned up message ['', 'move', 'p1a: Dragonite', 'Wrap', 'p2a: Chansey', '[from]Wrap']` I think always triggered by the length of the split message being 1 longer than expected due to the `[from]move`. I see this with Wrap, Bind, Solar Beam, Clamp. Can't tell if this has any impact on gameplay or is just a logging issue.

7. `AssertionError: Error with move mirrormove. Expected self.moves to contain copycat, metronome, mefirst, mirrormove, assist, transform or mimic. Got {'softboiled': softboiled (Move object), 'hyperbeam': hyperbeam (Move object), 'gust': gust (Move object), 'reflect': reflect (Move object)}`


PR has quick fixes to problems 1, 4, and 5.