### PR TITLE
Adding enumerations for the target property of moves

### DIFF
--- a/src/poke_env/environment/__init__.py
+++ b/src/poke_env/environment/__init__.py
@@ -47,6 +47,7 @@ __all__ = [
     "STACKABLE_CONDITIONS",
     "SideCondition",
     "Status",
+    "Target",
     "Weather",
     "Z_CRYSTAL",
     "abstract_battle",

--- a/src/poke_env/environment/__init__.py
+++ b/src/poke_env/environment/__init__.py
@@ -11,6 +11,7 @@ from poke_env.environment import (
     pokemon_type,
     side_condition,
     status,
+    target,
     weather,
     z_crystal,
 )
@@ -26,6 +27,7 @@ from poke_env.environment.pokemon_gender import PokemonGender
 from poke_env.environment.pokemon_type import PokemonType
 from poke_env.environment.side_condition import STACKABLE_CONDITIONS, SideCondition
 from poke_env.environment.status import Status
+from poke_env.environment.target import Target
 from poke_env.environment.weather import Weather
 from poke_env.environment.z_crystal import Z_CRYSTAL
 
@@ -59,6 +61,7 @@ __all__ = [
     "pokemon_type",
     "side_condition",
     "status",
+    "target",
     "weather",
     "z_crystal",
 ]

--- a/src/poke_env/environment/abstract_battle.py
+++ b/src/poke_env/environment/abstract_battle.py
@@ -751,6 +751,8 @@ class AbstractBattle(ABC):
             if pokemon.terastallized:
                 if pokemon in set(self.opponent_team.values()):
                     self._opponent_can_terrastallize = False
+        elif split_message[1] == "uhtml":
+            x=1
         else:
             raise NotImplementedError(split_message)
 

--- a/src/poke_env/environment/abstract_battle.py
+++ b/src/poke_env/environment/abstract_battle.py
@@ -751,8 +751,6 @@ class AbstractBattle(ABC):
             if pokemon.terastallized:
                 if pokemon in set(self.opponent_team.values()):
                     self._opponent_can_terrastallize = False
-        elif split_message[1] == "uhtml":
-            x=1
         else:
             raise NotImplementedError(split_message)
 

--- a/src/poke_env/environment/double_battle.py
+++ b/src/poke_env/environment/double_battle.py
@@ -355,7 +355,11 @@ class DoubleBattle(AbstractBattle):
         :rtype: int
         """
 
-        if move.target and move.target in (Target.ANY, Target.NORMAL) and target_mon is not None:
+        if (
+            move.target
+            and move.target in (Target.ANY, Target.NORMAL)
+            and target_mon is not None
+        ):
             if target_mon == self.active_pokemon[0]:
                 return self.POKEMON_1_POSITION
             elif target_mon == self.active_pokemon[1]:

--- a/src/poke_env/environment/double_battle.py
+++ b/src/poke_env/environment/double_battle.py
@@ -355,12 +355,12 @@ class DoubleBattle(AbstractBattle):
         :rtype: int
         """
 
-        if move.target in (Target.ANY, Target.NORMAL) and target_mon is not None:
+        if move.target and move.target in (Target.ANY, Target.NORMAL) and target_mon is not None:
             if target_mon == self.active_pokemon[0]:
                 return self.POKEMON_1_POSITION
             elif target_mon == self.active_pokemon[1]:
                 return self.POKEMON_2_POSITION
-            elif target_mon in self.opponent_active_pokemon[0]:
+            elif target_mon == self.opponent_active_pokemon[0]:
                 return self.OPPONENT_1_POSITION
             else:
                 return self.OPPONENT_2_POSITION

--- a/src/poke_env/environment/double_battle.py
+++ b/src/poke_env/environment/double_battle.py
@@ -287,29 +287,41 @@ class DoubleBattle(AbstractBattle):
             return [self.EMPTY_TARGET_POSITION]
         else:
             targets = {
-                "adjacentAlly": [ally_position],
-                "adjacentAllyOrSelf": [ally_position, self_position],
-                "adjacentFoe": [self.OPPONENT_1_POSITION, self.OPPONENT_2_POSITION],
-                "all": [self.EMPTY_TARGET_POSITION],
-                "allAdjacent": [self.EMPTY_TARGET_POSITION],
-                "allAdjacentFoes": [self.EMPTY_TARGET_POSITION],
-                "allies": [self.EMPTY_TARGET_POSITION],
-                "allySide": [self.EMPTY_TARGET_POSITION],
-                "allyTeam": [self.EMPTY_TARGET_POSITION],
-                "any": [
+                Target.from_showdown_message("adjacentAlly"): [ally_position],
+                Target.from_showdown_message("adjacentAllyOrSelf"): [
+                    ally_position,
+                    self_position,
+                ],
+                Target.from_showdown_message("adjacentFoe"): [
+                    self.OPPONENT_1_POSITION,
+                    self.OPPONENT_2_POSITION,
+                ],
+                Target.from_showdown_message("all"): [self.EMPTY_TARGET_POSITION],
+                Target.from_showdown_message("allAdjacent"): [
+                    self.EMPTY_TARGET_POSITION
+                ],
+                Target.from_showdown_message("allAdjacentFoes"): [
+                    self.EMPTY_TARGET_POSITION
+                ],
+                Target.from_showdown_message("allies"): [self.EMPTY_TARGET_POSITION],
+                Target.from_showdown_message("allySide"): [self.EMPTY_TARGET_POSITION],
+                Target.from_showdown_message("allyTeam"): [self.EMPTY_TARGET_POSITION],
+                Target.from_showdown_message("any"): [
                     ally_position,
                     self.OPPONENT_1_POSITION,
                     self.OPPONENT_2_POSITION,
                 ],
-                "foeSide": [self.EMPTY_TARGET_POSITION],
-                "normal": [
+                Target.from_showdown_message("foeSide"): [self.EMPTY_TARGET_POSITION],
+                Target.from_showdown_message("normal"): [
                     ally_position,
                     self.OPPONENT_1_POSITION,
                     self.OPPONENT_2_POSITION,
                 ],
-                "randomNormal": [self.EMPTY_TARGET_POSITION],
-                "scripted": [self.EMPTY_TARGET_POSITION],
-                "self": [self.EMPTY_TARGET_POSITION],
+                Target.from_showdown_message("randomNormal"): [
+                    self.EMPTY_TARGET_POSITION
+                ],
+                Target.from_showdown_message("scripted"): [self.EMPTY_TARGET_POSITION],
+                Target.from_showdown_message("self"): [self.EMPTY_TARGET_POSITION],
                 self.EMPTY_TARGET_POSITION: [self.EMPTY_TARGET_POSITION],
                 None: [self.OPPONENT_1_POSITION, self.OPPONENT_2_POSITION],
             }[move.deduced_target]
@@ -330,16 +342,16 @@ class DoubleBattle(AbstractBattle):
 
         return targets
 
-    def to_showdown_target(self, move: Move, target_mon: Pokemon) -> Optional[int]:
+    def to_showdown_target(self, move: Move, target_mon: Pokemon) -> int:
         """Returns the correct Showdown target of the Pokemon to be targeted.
-        It will return nothing if no target is needed or if the target_mon is not
-        an active pokemon
+        It will return 0 if no target is needed or if the target_mon is not
+        an active pokemon; this is meaningless in showdown
 
         :param move: the move to be used against the target_mon
         :type move: Move
         :param target_mon: the Pokemon that is to be targeted
         :type target_mon: as implemented in poke-env
-        :return: The corresponding showdown target if needed, otherwise nothing
+        :return: The corresponding showdown target if needed, otherwise 0
         :rtype: int
         """
 
@@ -355,7 +367,7 @@ class DoubleBattle(AbstractBattle):
 
         # No need to return a target for each of the other target types
         else:
-            return
+            return self.EMPTY_TARGET_POSITION
 
     @property
     def active_pokemon(self) -> List[Optional[Pokemon]]:

--- a/src/poke_env/environment/double_battle.py
+++ b/src/poke_env/environment/double_battle.py
@@ -355,7 +355,7 @@ class DoubleBattle(AbstractBattle):
         :rtype: int
         """
 
-        if order.move.target in (Target.ANY, Target.NORMAL):
+        if move.target in (Target.ANY, Target.NORMAL) and target_mon is not None:
             if target_mon == self.active_pokemon[0]:
                 return self.POKEMON_1_POSITION
             elif target_mon == self.active_pokemon[1]:

--- a/src/poke_env/environment/double_battle.py
+++ b/src/poke_env/environment/double_battle.py
@@ -6,6 +6,7 @@ from poke_env.environment.move import SPECIAL_MOVES, Move
 from poke_env.environment.move_category import MoveCategory
 from poke_env.environment.pokemon import Pokemon
 from poke_env.environment.pokemon_type import PokemonType
+from poke_env.environment.target import Target
 
 
 class DoubleBattle(AbstractBattle):
@@ -328,6 +329,33 @@ class DoubleBattle(AbstractBattle):
         targets = [target for target in targets if target in targets_to_keep]
 
         return targets
+
+    def to_showdown_target(self, move: Move, target_mon: Pokemon) -> Optional[int]:
+        """Returns the correct Showdown target of the Pokemon to be targeted.
+        It will return nothing if no target is needed or if the target_mon is not
+        an active pokemon
+
+        :param move: the move to be used against the target_mon
+        :type move: Move
+        :param target_mon: the Pokemon that is to be targeted
+        :type target_mon: as implemented in poke-env
+        :return: The corresponding showdown target if needed, otherwise nothing
+        :rtype: int
+        """
+
+        if order.move.target in (Target.ANY, Target.NORMAL):
+            if target_mon == self.active_pokemon[0]:
+                return self.POKEMON_1_POSITION
+            elif target_mon == self.active_pokemon[1]:
+                return self.POKEMON_2_POSITION
+            elif target_mon in self.opponent_active_pokemon[0]:
+                return self.OPPONENT_1_POSITION
+            else:
+                return self.OPPONENT_2_POSITION
+
+        # No need to return a target for each of the other target types
+        else:
+            return
 
     @property
     def active_pokemon(self) -> List[Optional[Pokemon]]:

--- a/src/poke_env/environment/move.py
+++ b/src/poke_env/environment/move.py
@@ -231,11 +231,11 @@ class Move:
         return self.entry.get("damage", 0)
 
     @property
-    def deduced_target(self) -> Optional[str]:
+    def deduced_target(self) -> Optional[Target]:
         """
         :return: Move deduced target, based on Move.target and showdown's request
             messages.
-        :rtype: str, optional
+        :rtype: Optional[Target]
         """
         if self.id in SPECIAL_MOVES:
             return self.target
@@ -512,19 +512,19 @@ class Move:
         return 0.0
 
     @property
-    def request_target(self) -> Optional[str]:
+    def request_target(self) -> Optional[Target]:
         """
         :return: Target information sent by showdown in a request message, if any.
-        :rtype: str, optional
+        :rtype: Optional[Target]
         """
         return self._request_target
 
     @request_target.setter
-    def request_target(self, request_target: Optional[str]):
+    def request_target(self, request_target: str):
         """
         :param request_target: Target information received from showdown in a request
             message.
-        "type request_target: Target, optional
+        :type request_target: str
         """
         self._request_target = Target.from_showdown_message(request_target)
 
@@ -639,10 +639,10 @@ class Move:
         return self.entry.get("stealsBoosts", False)
 
     @property
-    def target(self) -> str:
+    def target(self) -> Optional[Target]:
         """
         :return: Target of the move
-        :rtype: str
+        :rtype: Optional[Target]
         """
         if "target" in self.entry:
             return Target.from_showdown_message(self.entry["target"])

--- a/src/poke_env/environment/move.py
+++ b/src/poke_env/environment/move.py
@@ -524,9 +524,9 @@ class Move:
         """
         :param request_target: Target information received from showdown in a request
             message.
-        "type request_target: str, optional
+        "type request_target: Target, optional
         """
-        self._request_target = request_target
+        self._request_target = Target.from_showdown_message(request_target)
 
     @staticmethod
     @lru_cache(maxsize=4096)
@@ -645,7 +645,7 @@ class Move:
         :rtype: str
         """
         if "target" in self.entry:
-            return Target[self.entry["target"].upper()]
+            return Target.from_showdown_message(self.entry["target"])
         return None
 
     @property

--- a/src/poke_env/environment/move.py
+++ b/src/poke_env/environment/move.py
@@ -7,6 +7,7 @@ from poke_env.environment.field import Field
 from poke_env.environment.move_category import MoveCategory
 from poke_env.environment.pokemon_type import PokemonType
 from poke_env.environment.status import Status
+from poke_env.environment.target import Target
 from poke_env.environment.weather import Weather
 
 SPECIAL_MOVES: Set[str] = {"struggle", "recharge"}
@@ -640,28 +641,12 @@ class Move:
     @property
     def target(self) -> str:
         """
-        :return: Move target. Possible targets (copied from PS codebase):
-
-            * adjacentAlly - Only relevant to Doubles or Triples, the move only
-              targets an ally of the user.
-            * adjacentAllyOrSelf - The move can target the user or its ally.
-            * adjacentFoe - The move can target a foe, but not (in Triples)
-              a distant foe.
-            * all - The move targets the field or all Pokémon at once.
-            * allAdjacent - The move is a spread move that also hits the user's ally.
-            * allAdjacentFoes - The move is a spread move.
-            * allies - The move affects all active Pokémon on the user's team.
-            * allySide - The move adds a side condition on the user's side.
-            * allyTeam - The move affects all unfainted Pokémon on the user's team.
-            * any - The move can hit any other active Pokémon, not just those adjacent.
-            * foeSide - The move adds a side condition on the foe's side.
-            * normal - The move can hit one adjacent Pokémon of your choice.
-            * randomNormal - The move targets an adjacent foe at random.
-            * scripted - The move targets the foe that damaged the user.
-            * self - The move affects the user of the move.
+        :return: Target of the move
         :rtype: str
         """
-        return self.entry["target"]
+        if "target" in self.entry:
+            return Target[self.entry["target"].upper()]
+        return None
 
     @property
     def terrain(self) -> Optional[Field]:

--- a/src/poke_env/environment/target.py
+++ b/src/poke_env/environment/target.py
@@ -8,7 +8,6 @@ import logging
 # from poke_env.environment.pokemon import Pokemon
 import re
 from enum import Enum, unique, auto
-from typing import Optional
 
 
 # This is an enum for all the targets you can have

--- a/src/poke_env/environment/target.py
+++ b/src/poke_env/environment/target.py
@@ -3,7 +3,12 @@ targets a move can have
 """
 
 import logging
+# from poke_env.environment.double_battle import DoubleBattle
+# from poke_env.environment.pokemon import Pokemon
+import re
 from enum import Enum, unique, auto
+from typing import Optional
+
 
 # This is an enum for all the targets you can have
 @unique
@@ -11,20 +16,19 @@ class Target(Enum):
     """Enumeration, representing targets for each move
     in a battle."""
 
-    UNKNOWN = auto()
-    ADJACENTALLY = auto()
-    ADJACENTALLYORSELF = auto()
-    ADJACENTFOE = auto()
+    ADJACENT_ALLY = auto()
+    ADJACENT_ALLY_OR_SELF = auto()
+    ADJACENT_FOE = auto()
     ALL = auto()
-    ALLADJACENT = auto()
-    ALLADJACENTFOES = auto()
+    ALL_ADJACENT = auto()
+    ALL_ADJACENT_FOES = auto()
     ALLIES = auto()
-    ALLYSIDE = auto()
-    ALLYTEAM = auto()
+    ALLY_SIDE = auto()
+    ALLY_TEAM = auto()
     ANY = auto()
-    FOESIDE = auto()
+    FOE_SIDE = auto()
     NORMAL = auto()
-    RANDOMNORMAL = auto()
+    RANDOM_NORMAL = auto()
     SCRIPTED = auto()
     SELF = auto()
 
@@ -45,13 +49,15 @@ class Target(Enum):
         message = message.replace("-", "_")
 
         try:
-            return Target[message.upper()]
+            # Converts Camel Case targets to readable targets above
+            tokens = re.sub('([A-Z]+)', r' \1', message).split()
+            return Target['_'.join(tokens).upper()]
         except KeyError:
-            logging.getLogger("poke-env").warning(
-                "Unexpected Target '%s' received. Target.UNKNOWN will be used "
-                "instead. If this is unexpected, please open an issue at "
-                "https://github.com/hsahovic/poke-env/issues/ along with this error "
-                "message and a description of your program.",
+            logging.getLogger("poke-env").error(
+                "Unexpected Target '%s' received. If this is unexpected, please"
+                "open an issue at https://github.com/hsahovic/poke-env/issues/"
+                "along with this error message and a description of your "
+                "program.",
                 message,
             )
-            return Target.UNKNOWN
+            raise KeyError

--- a/src/poke_env/environment/target.py
+++ b/src/poke_env/environment/target.py
@@ -3,6 +3,7 @@ targets a move can have
 """
 
 import logging
+
 # from poke_env.environment.double_battle import DoubleBattle
 # from poke_env.environment.pokemon import Pokemon
 import re
@@ -50,8 +51,8 @@ class Target(Enum):
 
         try:
             # Converts Camel Case targets to readable targets above
-            tokens = re.sub('([A-Z]+)', r' \1', message).split()
-            return Target['_'.join(tokens).upper()]
+            tokens = re.sub("([A-Z]+)", r" \1", message).split()
+            return Target["_".join(tokens).upper()]
         except KeyError:
             logging.getLogger("poke-env").error(
                 "Unexpected Target '%s' received. If this is unexpected, please"

--- a/src/poke_env/environment/target.py
+++ b/src/poke_env/environment/target.py
@@ -1,0 +1,57 @@
+"""This module defines the Target class, which represents the types of
+targets a move can have
+"""
+
+import logging
+from enum import Enum, unique, auto
+
+# This is an enum for all the targets you can have
+@unique
+class Target(Enum):
+    """Enumeration, representing targets for each move
+    in a battle."""
+
+    UNKNOWN = auto()
+    ADJACENTALLY = auto()
+    ADJACENTALLYORSELF = auto()
+    ADJACENTFOE = auto()
+    ALL = auto()
+    ALLADJACENT = auto()
+    ALLADJACENTFOES = auto()
+    ALLIES = auto()
+    ALLYSIDE = auto()
+    ALLYTEAM = auto()
+    ANY = auto()
+    FOESIDE = auto()
+    NORMAL = auto()
+    RANDOMNORMAL = auto()
+    SCRIPTED = auto()
+    SELF = auto()
+
+    def __str__(self) -> str:
+        return f"{self.name} (target) object"
+
+    @staticmethod
+    def from_showdown_message(message: str):
+        """Returns the Target object corresponding to the message.
+
+        :param message: The message to convert.
+        :type message: str
+        :return: The corresponding Target object.
+        :rtype: Target
+        """
+        message = message.replace("move: ", "")
+        message = message.replace(" ", "_")
+        message = message.replace("-", "_")
+
+        try:
+            return Target[message.upper()]
+        except KeyError:
+            logging.getLogger("poke-env").warning(
+                "Unexpected Target '%s' received. Target.UNKNOWN will be used "
+                "instead. If this is unexpected, please open an issue at "
+                "https://github.com/hsahovic/poke-env/issues/ along with this error "
+                "message and a description of your program.",
+                message,
+            )
+            return Target.UNKNOWN

--- a/src/poke_env/environment/target.py
+++ b/src/poke_env/environment/target.py
@@ -7,7 +7,7 @@ import logging
 # from poke_env.environment.double_battle import DoubleBattle
 # from poke_env.environment.pokemon import Pokemon
 import re
-from enum import Enum, unique, auto
+from enum import Enum, auto, unique
 
 
 # This is an enum for all the targets you can have

--- a/unit_tests/environment/test_double_battle.py
+++ b/unit_tests/environment/test_double_battle.py
@@ -131,6 +131,22 @@ def test_get_possible_showdown_targets(example_doubles_request):
     assert battle.get_possible_showdown_targets(slackoff, mr_rime, dynamax=True) == [0]
 
 
+def test_to_showdown_target(example_doubles_request):
+    logger = MagicMock()
+    battle = DoubleBattle("tag", "username", logger, gen=8)
+
+    battle.parse_request(example_doubles_request)
+    mr_rime, klinklang = battle.active_pokemon
+    opp1, opp2 = battle.opponent_active_pokemon
+    psychic = mr_rime.moves["psychic"]
+    slackoff = mr_rime.moves["slackoff"]
+
+    assert battle.to_showdown_target(psychic, klinklang) == -2
+    assert battle.to_showdown_target(psychic, opp1) == 0
+    assert battle.to_showdown_target(slackoff, mr_rime) == 0
+    assert battle.to_showdown_target(slackoff, None) == 0
+
+
 def test_end_illusion():
     logger = MagicMock()
     battle = DoubleBattle("tag", "username", logger, gen=8)

--- a/unit_tests/environment/test_enumerations.py
+++ b/unit_tests/environment/test_enumerations.py
@@ -88,6 +88,3 @@ def test_target_str():
 
 def test_target_build():
     assert Target["ALLIES"] == Target.from_showdown_message("allies")
-    assert Target["UNKNOWN"] == Target.from_showdown_message(
-        "never gonna give you up"
-    )

--- a/unit_tests/environment/test_enumerations.py
+++ b/unit_tests/environment/test_enumerations.py
@@ -8,6 +8,7 @@ from poke_env.environment import (
     PokemonGender,
     SideCondition,
     Status,
+    Target,
     Weather,
 )
 
@@ -79,3 +80,14 @@ def test_side_condition_build():
 def test_weather_str():
     assert str(Weather["HAIL"])
     assert Weather["UNKNOWN"] == Weather.from_showdown_message("hehehe")
+
+
+def test_target_str():
+    assert str(Target["ALL"])
+
+
+def test_target_build():
+    assert Target["ALLIES"] == Target.from_showdown_message("allies")
+    assert Target["UNKNOWN"] == Target.from_showdown_message(
+        "never gonna give you up"
+    )

--- a/unit_tests/environment/test_move.py
+++ b/unit_tests/environment/test_move.py
@@ -456,12 +456,13 @@ def test_steals_boosts():
     for move in move_generator():
         assert isinstance(move.steals_boosts, bool)
 
+
 def test_target():
     flame_thrower = Move("flamethrower", gen=8)
     earthquake = Move("earthquake", gen=8)
 
-    assert earthquake.target == Target["ALLADJACENT"]
-    assert flame_thrower.target == Target["NORMAL"]
+    assert earthquake.target == Target.ALL_ADJACENT
+    assert flame_thrower.target == Target.NORMAL
 
     for move in move_generator():
         assert isinstance(move.target, Target)

--- a/unit_tests/environment/test_move.py
+++ b/unit_tests/environment/test_move.py
@@ -8,6 +8,7 @@ from poke_env.environment import (
     MoveCategory,
     PokemonType,
     Status,
+    Target,
     Weather,
 )
 
@@ -455,16 +456,15 @@ def test_steals_boosts():
     for move in move_generator():
         assert isinstance(move.steals_boosts, bool)
 
-
 def test_target():
     flame_thrower = Move("flamethrower", gen=8)
     earthquake = Move("earthquake", gen=8)
 
-    assert earthquake.target == "allAdjacent"
-    assert flame_thrower.target == "normal"
+    assert earthquake.target == Target["ALLADJACENT"]
+    assert flame_thrower.target == Target["NORMAL"]
 
     for move in move_generator():
-        assert isinstance(move.target, str)
+        assert isinstance(move.target, Target)
 
 
 def test_terrain():


### PR DESCRIPTION
Adding enumerations for the .target() field in Move class, to make it easier to embed moves via OHE.

Changes:
1. Created an enumeration class of Target
2. Changed move.target to return this enumeration
3. Added unit tests to test the enumeration
4. Added unit tests to test target in moves

All unit tests passed in both test_move and test_enumeration

This is in response to [issue #525](https://github.com/hsahovic/poke-env/issues/525), but only addresses the Target field because you already have encoded volatile statuses in effect.py