### PR TITLE
Open Team Sheets

### DIFF
--- a/src/poke_env/environment/target.py
+++ b/src/poke_env/environment/target.py
@@ -3,7 +3,6 @@ targets a move can have
 """
 
 import logging
-
 import re
 from enum import Enum, auto, unique
 

--- a/src/poke_env/player/player.py
+++ b/src/poke_env/player/player.py
@@ -56,6 +56,7 @@ class Player(ABC):
         battle_format: str = "gen9randombattle",
         log_level: Optional[int] = None,
         max_concurrent_battles: int = 1,
+        open_team_sheet: bool = False,
         save_replays: Union[bool, str] = False,
         server_configuration: Optional[ServerConfiguration] = None,
         start_timer_on_battle_start: bool = False,
@@ -79,6 +80,9 @@ class Player(ABC):
         :param max_concurrent_battles: Maximum number of battles this player will play
             concurrently. If 0, no limit will be applied. Defaults to 1.
         :type max_concurrent_battles: int
+        :param open_team_sheet: Boolean to define whether we want to accept or reject open team
+            sheet requests
+        :type team: bool
         :param save_replays: Whether to save battle replays. Can be a boolean, where
             True will lead to replays being saved in a potentially new /replay folder,
             or a string representing a folder where replays will be saved.
@@ -129,6 +133,7 @@ class Player(ABC):
         self._max_concurrent_battles: int = max_concurrent_battles
         self._save_replays = save_replays
         self._start_timer_on_battle_start: bool = start_timer_on_battle_start
+        self._open_team_sheet: bool = open_team_sheet
 
         self._battles: Dict[str, AbstractBattle] = {}
         self._battle_semaphore: Semaphore = create_in_poke_loop(Semaphore, 0)
@@ -349,6 +354,9 @@ class Player(ABC):
                 await self._handle_battle_request(battle, from_teampreview_request=True)
             elif split_message[1] == "bigerror":
                 self.logger.warning("Received 'bigerror' message: %s", split_message)
+            elif split_message[1] == "uhtml":
+                if split_message[2] == "otsrequest":
+                    await self._handle_ots_request(battle.battle_tag)
             else:
                 battle.parse_message(split_message)
 
@@ -380,6 +388,13 @@ class Player(ABC):
             if len(split_message) >= 6:
                 if split_message[5] == self._format:
                     await self._challenge_queue.put(challenging_player)
+
+    async def _handle_ots_request(self, battle_tag: str):
+        """Handles an Open Team Sheet request."""
+        if self.open_team_sheet:
+            await self.ps_client.send_message("/acceptopenteamsheets", room=battle_tag)
+        else:
+            await self.ps_client.send_message("/rejectopenteamsheets", room=battle_tag)
 
     async def _update_challenges(self, split_message: List[str]):
         """Update internal challenge state.
@@ -821,6 +836,10 @@ class Player(ABC):
     @property
     def n_won_battles(self) -> int:
         return len([None for b in self._battles.values() if b.won])
+
+    @property
+    def open_team_sheet(self) -> bool:
+        return self._open_team_sheet
 
     @property
     def win_rate(self) -> float:

--- a/unit_tests/player/test_player_misc.py
+++ b/unit_tests/player/test_player_misc.py
@@ -39,6 +39,10 @@ def test_player_default_order():
     assert SimplePlayer().choose_default_move().message == "/choose default"
 
 
+def test_open_team_sheet():
+    assert SimplePlayer(open_team_sheet=True).open_team_sheet
+
+
 def test_random_teampreview():
     player = SimplePlayer()
     logger = MagicMock()
@@ -235,3 +239,15 @@ async def test_awaitable_move(send_message_patch):
     with patch.object(player, "choose_move", return_value=return_move()):
         await player._handle_battle_request(battle)
         send_message_patch.assert_called_with("/choose move bite", "bat1")
+
+
+@patch("poke_env.ps_client.ps_client.PSClient.send_message")
+@pytest.mark.asyncio
+async def test_handle_ots_request(send_message_patch):
+    player = SimplePlayer(start_listening=False, open_team_sheet=True)
+    battle = Battle("bat1", player.username, player.logger, 8)
+    battle._teampreview = False
+
+    await player._handle_ots_request(battle.battle_tag)
+
+    send_message_patch.assert_called_with("/acceptopenteamsheets", room="bat1")

--- a/unit_tests/player/test_player_misc.py
+++ b/unit_tests/player/test_player_misc.py
@@ -40,7 +40,9 @@ def test_player_default_order():
 
 
 def test_open_team_sheet():
-    assert SimplePlayer(open_team_sheet=True).open_team_sheet
+    assert SimplePlayer(accept_open_team_sheet=True).accept_open_team_sheet
+    assert not SimplePlayer(accept_open_team_sheet=False).accept_open_team_sheet
+    assert not SimplePlayer().accept_open_team_sheet
 
 
 def test_random_teampreview():
@@ -244,7 +246,7 @@ async def test_awaitable_move(send_message_patch):
 @patch("poke_env.ps_client.ps_client.PSClient.send_message")
 @pytest.mark.asyncio
 async def test_handle_ots_request(send_message_patch):
-    player = SimplePlayer(start_listening=False, open_team_sheet=True)
+    player = SimplePlayer(start_listening=False, accept_open_team_sheet=True)
     battle = Battle("bat1", player.username, player.logger, 8)
     battle._teampreview = False
 


### PR DESCRIPTION
Related to [Issue #530](https://github.com/hsahovic/poke-env/issues/530) added implementation to accept/reject open team sheets for formats that request it. By default, we reject open team sheets to save the privacy of the bots.

Changes:
1. Fixed a small lint error that popped up from my last PR
2. Added param on Player instantiation for open_team_sheet
3. Added property for open_team_sheet
4. Added a function to send the chat command to accept/reject team sheet request, upon request, with ps_client
5. Added unit tests

Also, learned my lesson! It passes:
1. isort
2. black
3. flake8
4. pytest unit_tests
5. pyright

Hopefully this one is more straightforward! 