### PR TITLE
Observations & ObservedPokemon

### DIFF
--- a/src/poke_env/environment/__init__.py
+++ b/src/poke_env/environment/__init__.py
@@ -7,6 +7,7 @@ from poke_env.environment import (
     move,
     move_category,
     observation,
+    observed_pokemon,
     pokemon,
     pokemon_gender,
     pokemon_type,
@@ -24,6 +25,7 @@ from poke_env.environment.field import Field
 from poke_env.environment.move import SPECIAL_MOVES, EmptyMove, Move
 from poke_env.environment.move_category import MoveCategory
 from poke_env.environment.observation import Observation
+from poke_env.environment.observed_pokemon import ObservedPokemon
 from poke_env.environment.pokemon import Pokemon
 from poke_env.environment.pokemon_gender import PokemonGender
 from poke_env.environment.pokemon_type import PokemonType
@@ -43,6 +45,7 @@ __all__ = [
     "Move",
     "MoveCategory",
     "Observation",
+    "ObservedPokemon",
     "Pokemon",
     "PokemonGender",
     "PokemonType",
@@ -61,6 +64,7 @@ __all__ = [
     "move",
     "move_category",
     "observation",
+    "observed_pokemon",
     "pokemon",
     "pokemon_gender",
     "pokemon_type",

--- a/src/poke_env/environment/__init__.py
+++ b/src/poke_env/environment/__init__.py
@@ -6,6 +6,7 @@ from poke_env.environment import (
     field,
     move,
     move_category,
+    observation,
     pokemon,
     pokemon_gender,
     pokemon_type,
@@ -22,6 +23,7 @@ from poke_env.environment.effect import Effect
 from poke_env.environment.field import Field
 from poke_env.environment.move import SPECIAL_MOVES, EmptyMove, Move
 from poke_env.environment.move_category import MoveCategory
+from poke_env.environment.observation import Observation
 from poke_env.environment.pokemon import Pokemon
 from poke_env.environment.pokemon_gender import PokemonGender
 from poke_env.environment.pokemon_type import PokemonType
@@ -40,6 +42,7 @@ __all__ = [
     "Field",
     "Move",
     "MoveCategory",
+    "Observation",
     "Pokemon",
     "PokemonGender",
     "PokemonType",
@@ -57,6 +60,7 @@ __all__ = [
     "field",
     "move",
     "move_category",
+    "observation",
     "pokemon",
     "pokemon_gender",
     "pokemon_type",

--- a/src/poke_env/environment/abstract_battle.py
+++ b/src/poke_env/environment/abstract_battle.py
@@ -349,7 +349,6 @@ class AbstractBattle(ABC):
         self._fields[field] = self.turn
 
     def _finish_battle(self):
-
         # Recording the battle state and save events as we finish up
         self.observations[self.turn] = self._current_observation
 

--- a/src/poke_env/environment/abstract_battle.py
+++ b/src/poke_env/environment/abstract_battle.py
@@ -1,6 +1,6 @@
 import os
 from abc import ABC, abstractmethod
-from copy import copy
+from copy import deepcopy
 from logging import Logger
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
@@ -533,13 +533,13 @@ class AbstractBattle(ABC):
 
             # Create New Observation and record battle state going into the next turn
             self._current_observation = Observation(
-                side_conditions=copy(self.side_conditions),
-                opponent_side_conditions=copy(self.opponent_side_conditions),
-                weather=copy(self.weather),
-                fields=copy(self.fields),
-                active_pokemon=copy(self.active_pokemon),
-                opponent_active_pokemon=copy(self.opponent_active_pokemon),
-                opponent_team=copy(self.opponent_team),
+                side_conditions=deepcopy(self.side_conditions),
+                opponent_side_conditions=deepcopy(self.opponent_side_conditions),
+                weather=deepcopy(self.weather),
+                fields=deepcopy(self.fields),
+                active_pokemon=deepcopy(self.active_pokemon),
+                opponent_active_pokemon=deepcopy(self.opponent_active_pokemon),
+                opponent_team=deepcopy(self.opponent_team),
             )
         elif split_message[1] == "-heal":
             pokemon, hp_status = split_message[2:4]

--- a/src/poke_env/environment/double_battle.py
+++ b/src/poke_env/environment/double_battle.py
@@ -351,7 +351,7 @@ class DoubleBattle(AbstractBattle):
 
         return targets
 
-    def to_showdown_target(self, move: Move, target_mon: Pokemon) -> int:
+    def to_showdown_target(self, move: Move, target_mon: Optional[Pokemon]) -> int:
         """Returns the correct Showdown target of the Pokemon to be targeted.
         It will return 0 if no target is needed or if the target_mon is not
         an active pokemon; this is meaningless in showdown

--- a/src/poke_env/environment/double_battle.py
+++ b/src/poke_env/environment/double_battle.py
@@ -366,7 +366,7 @@ class DoubleBattle(AbstractBattle):
 
         if (
             move.target
-            and move.target in (Target.ANY, Target.NORMAL)
+            and move.target in (Target.ANY, Target.NORMAL, Target.ADJACENT_FOE)
             and target_mon is not None
         ):
             if target_mon == self.active_pokemon[0]:

--- a/src/poke_env/environment/observation.py
+++ b/src/poke_env/environment/observation.py
@@ -12,7 +12,6 @@ from poke_env.environment.weather import Weather
 
 @dataclass
 class Observation:
-
     side_conditions: Dict[SideCondition, int] = field(default_factory=dict)
     opponent_side_conditions: Dict[SideCondition, int] = field(default_factory=dict)
 

--- a/src/poke_env/environment/observation.py
+++ b/src/poke_env/environment/observation.py
@@ -24,6 +24,6 @@ class Observation:
     ] = None
 
     # The opponent's team that has been exposed to the player, for VGC
-    opponent_team: Dict[str, ObservedPokemon] = field(default_factory=dict)
+    opponent_team: Dict[str, Optional[ObservedPokemon]] = field(default_factory=dict)
 
     events: List[List[str]] = field(default_factory=list)

--- a/src/poke_env/environment/observation.py
+++ b/src/poke_env/environment/observation.py
@@ -1,0 +1,29 @@
+"""This module defines the Observation class, which stores what an agent can observe
+at the end of each turn.
+"""
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Union
+
+from poke_env.environment.field import Field
+from poke_env.environment.pokemon import Pokemon
+from poke_env.environment.side_condition import SideCondition
+from poke_env.environment.weather import Weather
+
+
+@dataclass
+class Observation:
+
+    side_conditions: Dict[SideCondition, int] = field(default_factory=dict)
+    opponent_side_conditions: Dict[SideCondition, int] = field(default_factory=dict)
+
+    weather: Dict[Weather, int] = field(default_factory=dict)
+    fields: Dict[Field, int] = field(default_factory=dict)
+
+    active_pokemon: Union[Pokemon, List[Pokemon], None] = None
+    opponent_active_pokemon: Union[Pokemon, List[Pokemon], None] = None
+
+    # The opponent's team that has been exposed to the player, for VGC
+    opponent_team: Dict[str, Pokemon] = field(default_factory=dict)
+
+    events: List[List[str]] = field(default_factory=list)

--- a/src/poke_env/environment/observation.py
+++ b/src/poke_env/environment/observation.py
@@ -1,5 +1,4 @@
-"""This module defines the Observation class, which stores what an agent can observe
-at the end of each turn.
+"""This module defines the Observation class, which stores the state of the battle
 """
 
 from dataclasses import dataclass, field

--- a/src/poke_env/environment/observation.py
+++ b/src/poke_env/environment/observation.py
@@ -2,10 +2,10 @@
 """
 
 from dataclasses import dataclass, field
-from typing import Dict, List, Union
+from typing import Dict, List, Optional, Union
 
 from poke_env.environment.field import Field
-from poke_env.environment.pokemon import Pokemon
+from poke_env.environment.observed_pokemon import ObservedPokemon
 from poke_env.environment.side_condition import SideCondition
 from poke_env.environment.weather import Weather
 
@@ -18,10 +18,12 @@ class Observation:
     weather: Dict[Weather, int] = field(default_factory=dict)
     fields: Dict[Field, int] = field(default_factory=dict)
 
-    active_pokemon: Union[Pokemon, List[Pokemon], None] = None
-    opponent_active_pokemon: Union[Pokemon, List[Pokemon], None] = None
+    active_pokemon: Union[ObservedPokemon, List[Optional[ObservedPokemon]], None] = None
+    opponent_active_pokemon: Union[
+        ObservedPokemon, List[Optional[ObservedPokemon]], None
+    ] = None
 
     # The opponent's team that has been exposed to the player, for VGC
-    opponent_team: Dict[str, Pokemon] = field(default_factory=dict)
+    opponent_team: Dict[str, ObservedPokemon] = field(default_factory=dict)
 
     events: List[List[str]] = field(default_factory=list)

--- a/src/poke_env/environment/observed_pokemon.py
+++ b/src/poke_env/environment/observed_pokemon.py
@@ -1,0 +1,58 @@
+"""This module defines the ObservedPokmon class, which stores
+what we have observed about a pokemon throughout a battle
+"""
+
+import sys
+from copy import copy
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Union
+
+from poke_env.environment.move import Move
+from poke_env.environment.pokemon import Pokemon
+from poke_env.environment.pokemon_gender import PokemonGender
+from poke_env.environment.pokemon_type import PokemonType
+
+
+@dataclass
+class ObservedPokemon:
+
+    species: str
+    level: int
+    stats: Dict[str, Union[int, List[str]]] = None
+    moves: Dict[str, Move] = field(default_factory=dict)
+    ability: Optional[str] = ""
+    item: Optional[str] = None
+    gender: Optional[PokemonGender] = None
+    tera_type: Optional[PokemonType] = None
+    shiny: Optional[bool] = None
+
+    @staticmethod
+    def initial_stats() -> Dict[str, List[int]]:
+        return {
+            "atk": [0, sys.maxsize],
+            "def": [0, sys.maxsize],
+            "spa": [0, sys.maxsize],
+            "spd": [0, sys.maxsize],
+            "spe": [0, sys.maxsize],
+        }
+
+    @staticmethod
+    def from_pokemon(mon: Pokemon):
+        if mon is None:
+            return None
+
+        stats = ObservedPokemon.initial_stats()
+        if mon.stats is not None:
+            stats = {k: v for (k, v) in mon.stats.items()}
+
+        return ObservedPokemon(
+            species=mon.species,
+            stats=stats,
+            moves={k: copy(v) for (k, v) in mon.moves.items()},
+            ability=mon.ability,
+            item=mon.item,
+            gender=mon.gender,
+            tera_type=mon.tera_type,
+            shiny=mon.shiny,
+            level=mon.level,
+        )

--- a/src/poke_env/environment/observed_pokemon.py
+++ b/src/poke_env/environment/observed_pokemon.py
@@ -15,7 +15,6 @@ from poke_env.environment.pokemon_type import PokemonType
 
 @dataclass
 class ObservedPokemon:
-
     species: str
     level: int
     stats: Optional[Mapping[str, Union[List[int], int, None]]] = None

--- a/src/poke_env/environment/observed_pokemon.py
+++ b/src/poke_env/environment/observed_pokemon.py
@@ -5,7 +5,7 @@ what we have observed about a pokemon throughout a battle
 import sys
 from copy import copy
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Mapping, Optional, Union
 
 from poke_env.environment.move import Move
 from poke_env.environment.pokemon import Pokemon
@@ -18,7 +18,7 @@ class ObservedPokemon:
 
     species: str
     level: int
-    stats: Dict[str, Union[int, List[str]]] = None
+    stats: Optional[Mapping[str, Union[List[int], int, None]]] = None
     moves: Dict[str, Move] = field(default_factory=dict)
     ability: Optional[str] = ""
     item: Optional[str] = None

--- a/src/poke_env/environment/pokemon.py
+++ b/src/poke_env/environment/pokemon.py
@@ -854,6 +854,14 @@ class Pokemon:
         return self._terastallized
 
     @property
+    def tera_type(self) -> Optional[bool]:
+        """
+        :return: The Tera Type of the Pokemon, None if unnown
+        :rtype: Optional[PokemonType]
+        """
+        return self._terastallized_type
+
+    @property
     def type_1(self) -> PokemonType:
         """
         :return: The pokemon's first type.

--- a/src/poke_env/environment/pokemon.py
+++ b/src/poke_env/environment/pokemon.py
@@ -854,7 +854,7 @@ class Pokemon:
         return self._terastallized
 
     @property
-    def tera_type(self) -> Optional[bool]:
+    def tera_type(self) -> Optional[PokemonType]:
         """
         :return: The Tera Type of the Pokemon, None if unnown
         :rtype: Optional[PokemonType]

--- a/unit_tests/environment/test_double_battle.py
+++ b/unit_tests/environment/test_double_battle.py
@@ -140,11 +140,13 @@ def test_to_showdown_target(example_doubles_request):
     opp1, opp2 = battle.opponent_active_pokemon
     psychic = mr_rime.moves["psychic"]
     slackoff = mr_rime.moves["slackoff"]
+    dynamax_psychic = psychic.dynamaxed
 
     assert battle.to_showdown_target(psychic, klinklang) == -2
     assert battle.to_showdown_target(psychic, opp1) == 0
     assert battle.to_showdown_target(slackoff, mr_rime) == 0
     assert battle.to_showdown_target(slackoff, None) == 0
+    assert battle.to_showdown_target(dynamax_psychic, klinklang) == -2
 
 
 def test_end_illusion():

--- a/unit_tests/environment/test_observation.py
+++ b/unit_tests/environment/test_observation.py
@@ -1,0 +1,53 @@
+from unittest.mock import MagicMock
+
+from poke_env.environment import Battle, Field, Observation, SideCondition, Weather
+
+
+def test_observation(example_request):
+    logger = MagicMock()
+    battle = Battle("tag", "username", logger, gen=8)
+
+    battle.parse_request(example_request)
+    mon = battle.active_pokemon
+    battle._opponent_team = {mon.species: mon}
+
+    # Finish a turn and record the observation
+    battle.parse_message(["", "turn", "7"])
+    assert 7 in battle.observations
+    assert battle.observations[7].opponent_team[mon.species] == mon
+
+    assert len(battle._current_observation.weather) == 0
+    assert len(battle._current_observation.fields) == 0
+    assert len(battle._current_observation.fields) == 0
+
+    battle.parse_message(["", "-weather", "SunnyDay"])
+    battle.parse_message(["", "-fieldstart", "move: Grassy Terrain"])
+    battle.parse_message(["", "-sidestart", "p2: RandomPlayer 3", "move: Tailwind"])
+    battle.parse_message(["", "-sidestart", "p1: EliteFurretAI", "move: Tailwind"])
+    battle.parse_message(["", "-sidestart", "p1: EliteFurretAI", "move: Reflect"])
+
+    # Observations only get populated and stored at the end of the turn
+    # But events get captured as turns happen
+    assert Weather.SUNNYDAY not in battle._current_observation.weather
+    assert ["", "-weather", "SunnyDay"] in battle._current_observation.events
+
+    # End turn and store Observation
+    battle.parse_message(["", "turn", "8"])
+
+    # Check Observations
+    assert 7 in battle.observations
+    assert 8 in battle.observations
+    assert Weather.SUNNYDAY not in battle.observations[7].weather
+    assert Weather.SUNNYDAY in battle.observations[8].weather
+    assert Field.GRASSY_TERRAIN in battle.observations[8].fields
+    assert SideCondition.TAILWIND in battle.observations[8].opponent_side_conditions
+    assert SideCondition.REFLECT in battle.observations[8].opponent_side_conditions
+    assert [
+        "",
+        "-sidestart",
+        "p1: EliteFurretAI",
+        "move: Reflect",
+    ] in battle.observations[8].events
+
+    # Check to see if we restarted the observation in the new turn
+    assert battle._current_observation == Observation()

--- a/unit_tests/environment/test_observation.py
+++ b/unit_tests/environment/test_observation.py
@@ -25,6 +25,7 @@ def test_observation(example_request):
 
     battle.parse_message(["", "-weather", "Sandstorm"])
     battle.parse_message(["", "-fieldstart", "move: Grassy Terrain"])
+    battle.parse_message(["", "-fieldstart", "move: Magic Room"])
     battle.parse_message(["", "-sidestart", "p2: RandomPlayer 3", "move: Tailwind"])
     battle.parse_message(["", "-sidestart", "p1: EliteFurretAI", "move: Tailwind"])
     battle.parse_message(["", "-sidestart", "p1: EliteFurretAI", "move: Reflect"])
@@ -47,14 +48,18 @@ def test_observation(example_request):
     battle.parse_message(["", "turn", "3"])
     battle.parse_message(["", "-weather", "SunnyDay"])
 
-    # Check Observations
+    # Check Observations and all attributes
+    # TODO: check all observation attributes
     assert 2 in battle.observations
     assert 3 not in battle.observations
+    assert SideCondition.TAILWIND in battle.observations[2].opponent_side_conditions
+    assert SideCondition.TAILWIND in battle.observations[2].side_conditions
+    assert SideCondition.REFLECT in battle.observations[2].opponent_side_conditions
     assert Weather.SANDSTORM not in battle.observations[1].weather
     assert Weather.SANDSTORM in battle.observations[2].weather
     assert Field.GRASSY_TERRAIN in battle.observations[2].fields
-    assert SideCondition.TAILWIND in battle.observations[2].opponent_side_conditions
-    assert SideCondition.REFLECT in battle.observations[2].opponent_side_conditions
+    assert Field.MAGIC_ROOM in battle.observations[2].fields
+    assert mon.species == battle.observations[2].active_pokemon.species
 
     # Test whether we store the last turn
     battle.tied()

--- a/unit_tests/environment/test_observation.py
+++ b/unit_tests/environment/test_observation.py
@@ -62,8 +62,9 @@ def test_observation(example_request):
     assert Weather.SANDSTORM not in battle.observations[3].weather
 
 
-# TODO: test observedPokemon
 def test_observed_pokemon(example_request):
+    assert ObservedPokemon.from_pokemon(None) is None
+
     logger = MagicMock()
     battle = Battle("tag", "username", logger, gen=8)
 

--- a/unit_tests/environment/test_observation.py
+++ b/unit_tests/environment/test_observation.py
@@ -7,47 +7,56 @@ def test_observation(example_request):
     logger = MagicMock()
     battle = Battle("tag", "username", logger, gen=8)
 
+    # Check to see if we have no information
+    assert battle._current_observation == Observation()
+
     battle.parse_request(example_request)
     mon = battle.active_pokemon
     battle._opponent_team = {mon.species: mon}
 
-    # Finish a turn and record the observation
-    battle.parse_message(["", "turn", "7"])
-    assert 7 in battle.observations
-    assert battle.observations[7].opponent_team[mon.species] == mon
+    # Starting turn 1
+    battle.parse_message(["", "turn", "1"])
+
+    assert 0 in battle.observations
 
     assert len(battle._current_observation.weather) == 0
     assert len(battle._current_observation.fields) == 0
     assert len(battle._current_observation.fields) == 0
 
-    battle.parse_message(["", "-weather", "SunnyDay"])
+    battle.parse_message(["", "-weather", "Sandstorm"])
     battle.parse_message(["", "-fieldstart", "move: Grassy Terrain"])
     battle.parse_message(["", "-sidestart", "p2: RandomPlayer 3", "move: Tailwind"])
     battle.parse_message(["", "-sidestart", "p1: EliteFurretAI", "move: Tailwind"])
     battle.parse_message(["", "-sidestart", "p1: EliteFurretAI", "move: Reflect"])
 
-    # Observations only get populated and stored at the end of the turn
-    # But events get captured as turns happen
-    assert Weather.SUNNYDAY not in battle._current_observation.weather
-    assert ["", "-weather", "SunnyDay"] in battle._current_observation.events
+    # Observation events get captured as they happen
+    assert ["", "-weather", "Sandstorm"] in battle._current_observation.events
 
-    # End turn and store Observation
-    battle.parse_message(["", "turn", "8"])
+    # End turn 1 and store Observation of turn 1, going into turn 2
+    battle.parse_message(["", "turn", "2"])
 
-    # Check Observations
-    assert 7 in battle.observations
-    assert 8 in battle.observations
-    assert Weather.SUNNYDAY not in battle.observations[7].weather
-    assert Weather.SUNNYDAY in battle.observations[8].weather
-    assert Field.GRASSY_TERRAIN in battle.observations[8].fields
-    assert SideCondition.TAILWIND in battle.observations[8].opponent_side_conditions
-    assert SideCondition.REFLECT in battle.observations[8].opponent_side_conditions
+    assert battle.observations[1].opponent_team[mon.species] == mon
     assert [
         "",
         "-sidestart",
         "p1: EliteFurretAI",
         "move: Reflect",
-    ] in battle.observations[8].events
+    ] in battle.observations[1].events
 
-    # Check to see if we restarted the observation in the new turn
-    assert battle._current_observation == Observation()
+    # End turn and stoere Observation for turn 2
+    battle.parse_message(["", "turn", "3"])
+    battle.parse_message(["", "-weather", "SunnyDay"])
+
+
+    # Check Observations
+    assert 2 in battle.observations
+    assert 3 not in battle.observations
+    assert Weather.SANDSTORM not in battle.observations[1].weather
+    assert Weather.SANDSTORM in battle.observations[2].weather
+    assert Field.GRASSY_TERRAIN in battle.observations[2].fields
+    assert SideCondition.TAILWIND in battle.observations[2].opponent_side_conditions
+    assert SideCondition.REFLECT in battle.observations[2].opponent_side_conditions
+
+    # Test whether we store the last turn
+    battle.tied()
+    assert ["", "-weather", "SunnyDay"] in battle.observations[3].events

--- a/unit_tests/environment/test_observation.py
+++ b/unit_tests/environment/test_observation.py
@@ -14,53 +14,41 @@ def test_observation(example_request):
     mon = battle.active_pokemon
     battle._opponent_team = {mon.species: mon}
 
-    # Starting turn 1
+    # Observations encode each turn encode, and encode specifically the state of the
+    # battle at the beginning of each turn, and the events that happened on that turn
     battle.parse_message(["", "turn", "1"])
-
-    assert 0 in battle.observations
-
-    assert len(battle._current_observation.weather) == 0
-    assert len(battle._current_observation.fields) == 0
-    assert len(battle._current_observation.fields) == 0
-
     battle.parse_message(["", "-weather", "Sandstorm"])
     battle.parse_message(["", "-fieldstart", "move: Grassy Terrain"])
     battle.parse_message(["", "-fieldstart", "move: Magic Room"])
     battle.parse_message(["", "-sidestart", "p2: RandomPlayer 3", "move: Tailwind"])
     battle.parse_message(["", "-sidestart", "p1: EliteFurretAI", "move: Tailwind"])
     battle.parse_message(["", "-sidestart", "p1: EliteFurretAI", "move: Reflect"])
-
-    # Observation events get captured as they happen
-    assert ["", "-weather", "Sandstorm"] in battle._current_observation.events
-
-    # End turn 1 and store Observation of turn 1, going into turn 2
     battle.parse_message(["", "turn", "2"])
+    battle.parse_message(["", "-weather", "RainyDay"])
+    battle.parse_message(["", "turn", "3"])
+    battle.parse_message(["", "-weather", "SunnyDay"])
+    battle.tied()
 
-    assert battle.observations[1].opponent_team[mon.species] == mon
+    # Check all attributes of Observation, as well as if it updates the battle states
+    # correctly
     assert [
         "",
         "-sidestart",
         "p1: EliteFurretAI",
         "move: Reflect",
     ] in battle.observations[1].events
+    assert mon.species == battle.observations[1].active_pokemon.species
+    assert mon.species == battle.observations[1].opponent_active_pokemon.species
+    assert battle.observations[1].opponent_team[mon.species].species == mon.species
+    assert Weather.SANDSTORM not in battle.observations[1].weather
 
-    # End turn and stoere Observation for turn 2
-    battle.parse_message(["", "turn", "3"])
-    battle.parse_message(["", "-weather", "SunnyDay"])
-
-    # Check Observations and all attributes
-    # TODO: check all observation attributes
-    assert 2 in battle.observations
-    assert 3 not in battle.observations
     assert SideCondition.TAILWIND in battle.observations[2].opponent_side_conditions
     assert SideCondition.TAILWIND in battle.observations[2].side_conditions
     assert SideCondition.REFLECT in battle.observations[2].opponent_side_conditions
-    assert Weather.SANDSTORM not in battle.observations[1].weather
     assert Weather.SANDSTORM in battle.observations[2].weather
     assert Field.GRASSY_TERRAIN in battle.observations[2].fields
     assert Field.MAGIC_ROOM in battle.observations[2].fields
     assert mon.species == battle.observations[2].active_pokemon.species
 
-    # Test whether we store the last turn
-    battle.tied()
     assert ["", "-weather", "SunnyDay"] in battle.observations[3].events
+    assert Weather.SANDSTORM not in battle.observations[3].weather

--- a/unit_tests/environment/test_observation.py
+++ b/unit_tests/environment/test_observation.py
@@ -74,7 +74,6 @@ def test_observed_pokemon(example_request):
     assert observed_mon.species == mon.species
     assert observed_mon.level == mon.level
 
-    assert observed_mon.stats["hp"] == mon.max_hp
     assert observed_mon.stats["atk"] == mon.stats["atk"]
     assert observed_mon.stats["def"] == mon.stats["def"]
     assert observed_mon.stats["spa"] == mon.stats["spa"]

--- a/unit_tests/environment/test_pokemon.py
+++ b/unit_tests/environment/test_pokemon.py
@@ -1,4 +1,4 @@
-from poke_env.environment import Move, Pokemon, PokemonType
+from poke_env.environment import Move, Pokemon, PokemonGender, PokemonType
 
 
 def test_pokemon_moves():
@@ -166,3 +166,21 @@ def test_pokemon_base_species():
 
     assert arceus.base_species == "arceus"
     assert acreus_bug.base_species == "arceus"
+
+
+def test_tera_type():
+    charizard = Pokemon(species="charizard", gen=8)
+    assert charizard.tera_type is None
+    charizard.terastallize("bug")
+    assert charizard.tera_type == PokemonType.BUG
+
+
+def test_details():
+    details = "furret, L100, F, tera:normal, shiny"
+    furret = Pokemon(species="furret", gen=8, details=details)
+
+    assert furret.species == "furret"
+    assert furret.level == 100
+    assert furret.shiny
+    assert furret.gender == PokemonGender.FEMALE
+    assert furret.tera_type == PokemonType.NORMAL


### PR DESCRIPTION
1. Fixed bug in [Issue #541](https://github.com/hsahovic/poke-env/issues/541) and added a unit test to catch it
2. Added an observation class that stores observable information as the battle goes on.

On Observation class design, it catches all temporal effects that allow us to recreate a Public Belief State (all observable information)  at the time. This includes:
1. All Showdown event strings
2. Active Pokemon (on both sides of the field)
3. Field effects
4. Weather
5. Side Conditions (on both sides of the field)
6. Opponent's Team (important for moves like Last Respects and guessing what's in back for VGC)

With this information, you can recreate battle states for an agent to learn from, or feed into a model. Right now, there is no inference or processing on top of the raw data stored in the Observations class