### PR TITLE
Adding Volatile Status

### DIFF
--- a/src/poke_env/environment/__init__.py
+++ b/src/poke_env/environment/__init__.py
@@ -14,6 +14,7 @@ from poke_env.environment import (
     side_condition,
     status,
     target,
+    volatile_status,
     weather,
     z_crystal,
 )
@@ -32,6 +33,7 @@ from poke_env.environment.pokemon_type import PokemonType
 from poke_env.environment.side_condition import STACKABLE_CONDITIONS, SideCondition
 from poke_env.environment.status import Status
 from poke_env.environment.target import Target
+from poke_env.environment.volatile_status import VolatileStatus
 from poke_env.environment.weather import Weather
 from poke_env.environment.z_crystal import Z_CRYSTAL
 
@@ -54,6 +56,7 @@ __all__ = [
     "SideCondition",
     "Status",
     "Target",
+    "VolatileStatus",
     "Weather",
     "Z_CRYSTAL",
     "abstract_battle",
@@ -71,6 +74,7 @@ __all__ = [
     "side_condition",
     "status",
     "target",
+    "volatile_status",
     "weather",
     "z_crystal",
 ]

--- a/src/poke_env/environment/move.py
+++ b/src/poke_env/environment/move.py
@@ -8,6 +8,7 @@ from poke_env.environment.move_category import MoveCategory
 from poke_env.environment.pokemon_type import PokemonType
 from poke_env.environment.status import Status
 from poke_env.environment.target import Target
+from poke_env.environment.volatile_status import VolatileStatus
 from poke_env.environment.weather import Weather
 
 SPECIAL_MOVES: Set[str] = {"struggle", "recharge"}
@@ -681,12 +682,15 @@ class Move:
         return self.entry.get("overrideOffensivePokemon", False) == "target"
 
     @property
-    def volatile_status(self) -> Optional[str]:
+    def volatile_status(self) -> Optional[VolatileStatus]:
         """
         :return: Volatile status inflicted by the move.
         :rtype: str | None
         """
-        return self.entry.get("volatileStatus", None)
+        volatile_status = self.entry.get("volatileStatus", None)
+        if volatile_status is not None:
+            return VolatileStatus.from_name(volatile_status)
+        return volatile_status
 
     @property
     def weather(self) -> Optional[Weather]:

--- a/src/poke_env/environment/volatile_status.py
+++ b/src/poke_env/environment/volatile_status.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+"""This module defines the VolatileStatus class, which represents a field a Move
+can have.
+"""
+from __future__ import annotations
+
+# pyre-ignore-all-errors[45]
+from enum import Enum, auto, unique
+
+
+# This is an enum for all the Volatile Statuses a move can have
+@unique
+class VolatileStatus(Enum):
+    """Enumeration, represent a volatilestatus a move can have."""
+
+    FORESIGHT = auto()
+    DISABLE = auto()
+    SMACKDOWN = auto()
+    CURSE = auto()
+    NIGHTMARE = auto()
+    TARSHOT = auto()
+    LOCKEDMOVE = auto()
+    BIDE = auto()
+    SNATCH = auto()
+    ENCORE = auto()
+    SPOTLIGHT = auto()
+    LASERFOCUS = auto()
+    ELECTRIFY = auto()
+    SILKTRAP = auto()
+    HEALBLOCK = auto()
+    MIRACLEEYE = auto()
+    ATTRACT = auto()
+    DESTINYBOND = auto()
+    RAGE = auto()
+    AQUARING = auto()
+    TAUNT = auto()
+    TELEKINESIS = auto()
+    GRUDGE = auto()
+    SYRUPBOMB = auto()
+    YAWN = auto()
+    IMPRISON = auto()
+    MAGICCOAT = auto()
+    STOCKPILE = auto()
+    DEFENSECURL = auto()
+    EMBARGO = auto()
+    FOLLOWME = auto()
+    GLAIVERUSH = auto()
+    CONFUSION = auto()
+    INGRAIN = auto()
+    BANEFULBUNKER = auto()
+    PROTECT = auto()
+    GASTROACID = auto()
+    POWERTRICK = auto()
+    TORMENT = auto()
+    BURNINGBULWARK = auto()
+    DRAGONCHEER = auto()
+    SPARKLINGARIA = auto()
+    HELPINGHAND = auto()
+    FLINCH = auto()
+    OCTOLOCK = auto()
+    PARTIALLYTRAPPED = auto()
+    KINGSSHIELD = auto()
+    MINIMIZE = auto()
+    NORETREAT = auto()
+    CHARGE = auto()
+    MUSTRECHARGE = auto()
+    MAGNETRISE = auto()
+    MAXGUARD = auto()
+    POWERSHIFT = auto()
+    SUBSTITUTE = auto()
+    RAGEPOWDER = auto()
+    ROOST = auto()
+    FOCUSENERGY = auto()
+    SALTCURE = auto()
+    LEECHSEED = auto()
+    POWDER = auto()
+    SPIKYSHIELD = auto()
+    ENDURE = auto()
+    UPROAR = auto()
+    OBSTRUCT = auto()
+
+    def __str__(self) -> str:
+        return f"{self.name} (volatile status) object"
+
+    @staticmethod
+    def from_name(name: str) -> VolatileStatus:
+        """Returns a volatile status based on its name.
+
+        :param name: The name of the volatile status.
+        :type name: str
+        :return: The corresponding type object.
+        :rtype: VolatileStatus
+        """
+        return VolatileStatus[name.upper()]

--- a/unit_tests/environment/test_move.py
+++ b/unit_tests/environment/test_move.py
@@ -9,6 +9,7 @@ from poke_env.environment import (
     PokemonType,
     Status,
     Target,
+    VolatileStatus,
     Weather,
 )
 
@@ -513,11 +514,14 @@ def test_volatile_status():
     flame_thrower = Move("flamethrower", gen=8)
     heal_block = Move("healblock", gen=8)
 
-    assert heal_block.volatile_status == "healblock"
+    assert heal_block.volatile_status == VolatileStatus.HEALBLOCK
     assert flame_thrower.volatile_status is None
 
     for move in move_generator():
-        assert isinstance(move.volatile_status, str) or move.volatile_status is None
+        assert (
+            isinstance(move.volatile_status, VolatileStatus)
+            or move.volatile_status is None
+        )
 
 
 def test_weather():


### PR DESCRIPTION
I wanted to add an enum for VolatileStatus to make it easier to embed. What this PR has:
1. Adding VolatileStatus (a semi-common field in moves data) as an enum
2. Changing Moves to return a VolatileStatus object, when requesting a move's volatile_status
3. Adding a unit test to moves to test VolatileStatus