### PR TITLE
Fixed Move SideConditions and corrected protect classifications

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -39,7 +39,7 @@ def raw_team_data():
 def example_request():
     with open(os.path.join(FIXTURE_DIR, "example_request.json")) as f:
         return orjson.loads(f.read())
-    
+
 
 @fixture
 def force_switch_example_request():

--- a/src/poke_env/environment/move.py
+++ b/src/poke_env/environment/move.py
@@ -7,6 +7,7 @@ from poke_env.environment.effect import Effect
 from poke_env.environment.field import Field
 from poke_env.environment.move_category import MoveCategory
 from poke_env.environment.pokemon_type import PokemonType
+from poke_env.environment.side_condition import SideCondition
 from poke_env.environment.status import Status
 from poke_env.environment.target import Target
 from poke_env.environment.weather import Weather
@@ -20,11 +21,13 @@ _PROTECT_MOVES = {
     "spikyshield",
     "kingsshield",
     "banefulbunker",
+    "burningbulwark",
     "obstruct",
     "maxguard",
+    "silktrap",
 }
 _SIDE_PROTECT_MOVES = {"wideguard", "quickguard", "matblock"}
-_PROTECT_COUNTER_MOVES = _PROTECT_MOVES | _SIDE_PROTECT_MOVES
+_PROTECT_COUNTER_MOVES = _PROTECT_MOVES | {"wideguard", "quickguard", "endure"}
 
 
 class Move:
@@ -587,12 +590,15 @@ class Move:
         return self.entry.get("selfSwitch", False)
 
     @property
-    def side_condition(self) -> Optional[str]:
+    def side_condition(self) -> Optional[SideCondition]:
         """
         :return: Side condition inflicted by the move.
-        :rtype: str | None
+        :rtype: SideCondition | None
         """
-        return self.entry.get("sideCondition", None)
+        sc = self.entry.get("sideCondition", None)
+        if sc is not None:
+            sc = SideCondition.from_data(sc)
+        return sc
 
     @property
     def sleep_usable(self) -> bool:

--- a/src/poke_env/environment/side_condition.py
+++ b/src/poke_env/environment/side_condition.py
@@ -4,6 +4,7 @@ condition.
 
 import logging
 from enum import Enum, auto, unique
+from typing import Dict
 
 
 @unique
@@ -12,6 +13,7 @@ class SideCondition(Enum):
 
     UNKNOWN = auto()
     AURORA_VEIL = auto()
+    CRAFTY_SHIELD = auto()
     FIRE_PLEDGE = auto()
     G_MAX_CANNONADE = auto()
     G_MAX_STEELSURGE = auto()
@@ -21,7 +23,9 @@ class SideCondition(Enum):
     GRASS_PLEDGE = auto()
     LIGHT_SCREEN = auto()
     LUCKY_CHANT = auto()
+    MATBLOCK = auto()
     MIST = auto()
+    QUICK_GUARD = auto()
     REFLECT = auto()
     SAFEGUARD = auto()
     SPIKES = auto()
@@ -30,6 +34,7 @@ class SideCondition(Enum):
     TAILWIND = auto()
     TOXIC_SPIKES = auto()
     WATER_PLEDGE = auto()
+    WIDE_GUARD = auto()
 
     def __str__(self) -> str:
         return f"{self.name} (side condition) object"
@@ -59,6 +64,59 @@ class SideCondition(Enum):
             )
             return SideCondition.UNKNOWN
 
+    @staticmethod
+    def from_data(message: str):
+        """Returns the SideCondition object corresponding to the string in static data.
+
+        :param message: The message to convert.
+        :type message: str
+        :return: The corresponding SideCondition object.
+        :rtype: SideCondition
+        """
+        message = message.replace("_", "")
+        message = message.replace(" ", "")
+        message = message.replace("-", "")
+        message = message.upper()
+
+        try:
+            return _FROM_DATA[message]
+        except KeyError:
+            logging.getLogger("poke-env").warning(
+                "Unexpected SideCondition '%s' received. SideCondition.UNKNOWN will be used "
+                "instead. If this is unexpected, please open an issue at "
+                "https://github.com/hsahovic/poke-env/issues/ along with this error "
+                "message and a description of your program.",
+                message,
+            )
+            return SideCondition.UNKNOWN
+
 
 # SideCondition -> Max useful stack level
 STACKABLE_CONDITIONS = {SideCondition.SPIKES: 3, SideCondition.TOXIC_SPIKES: 2}
+
+_FROM_DATA: Dict[str, SideCondition] = {
+    "UNKNOWN": SideCondition.UNKNOWN,
+    "AURORAVEIL": SideCondition.AURORA_VEIL,
+    "CRAFTYSHIELD": SideCondition.CRAFTY_SHIELD,
+    "FIREPLEDGE": SideCondition.FIRE_PLEDGE,
+    "GMAXCANNONADE": SideCondition.G_MAX_CANNONADE,
+    "GMAXSTEELSURGE": SideCondition.G_MAX_STEELSURGE,
+    "GMAXVINELASH": SideCondition.G_MAX_VINE_LASH,
+    "GMAXVOLCALITH": SideCondition.G_MAX_VOLCALITH,
+    "GMAXWILDFIRE": SideCondition.G_MAX_WILDFIRE,
+    "GRASSPLEDGE": SideCondition.GRASS_PLEDGE,
+    "LIGHTSCREEN": SideCondition.LIGHT_SCREEN,
+    "LUCKYCHANT": SideCondition.LUCKY_CHANT,
+    "MATBLOCK": SideCondition.MATBLOCK,
+    "MIST": SideCondition.MIST,
+    "QUICKGUARD": SideCondition.QUICK_GUARD,
+    "REFLECT": SideCondition.REFLECT,
+    "SAFEGUARD": SideCondition.SAFEGUARD,
+    "SPIKES": SideCondition.SPIKES,
+    "STEALTHROCK": SideCondition.STEALTH_ROCK,
+    "STICKYWEB": SideCondition.STICKY_WEB,
+    "TAILWIND": SideCondition.TAILWIND,
+    "TOXICSPIKES": SideCondition.TOXIC_SPIKES,
+    "WATERPLEDGE": SideCondition.WATER_PLEDGE,
+    "WIDEGUARD": SideCondition.WIDE_GUARD,
+}


### PR DESCRIPTION
Did a couple of small things:
1. Fixed Protect Classifications, according to [Bulbapedia](https://bulbapedia.bulbagarden.net/wiki/Protection#Moves_that_protect_the_user)
2. Added `SideCondition`s found in `Move`s that weren't previously recorded (collected through regex filtering of `gen[1-9]moves.json`)
3. Fixed `move.side_condition` to return a `SideCondition` object, consistent with `Terrain`/`Weather`/`Effect`/`Status`
4. Added tests for `SideCondition` to ensure better maintainability, similar to what I did with `volatile_status` -- ensuring that if a new `SideCondition` pops up, we will have it captured in the enum. Also ensuring that we don't have extra `SideCondition`s not available in Showdown
5. Added small functionality to `move_generator` in `test_move` so that we can more easily test different generations of moves to ensure multi-generational compatibility