### PR TITLE
Added empty event tracking

### DIFF
--- a/src/poke_env/environment/abstract_battle.py
+++ b/src/poke_env/environment/abstract_battle.py
@@ -62,7 +62,7 @@ class AbstractBattle(ABC):
         "upkeep",
         "uhtml",
         "zbroken",
-        ""
+        "",
     }
 
     __slots__ = (

--- a/src/poke_env/environment/abstract_battle.py
+++ b/src/poke_env/environment/abstract_battle.py
@@ -62,6 +62,7 @@ class AbstractBattle(ABC):
         "upkeep",
         "uhtml",
         "zbroken",
+        ""
     }
 
     __slots__ = (

--- a/src/poke_env/player/player.py
+++ b/src/poke_env/player/player.py
@@ -42,7 +42,7 @@ class Player(ABC):
     Base class for players.
     """
 
-    MESSAGES_TO_IGNORE = {"", "t:", "expire", "uhtmlchange"}
+    MESSAGES_TO_IGNORE = {"t:", "expire", "uhtmlchange"}
 
     # When an error resulting from an invalid choice is made, the next order has this
     # chance of being showdown's default order to prevent infinite loops
@@ -260,6 +260,8 @@ class Player(ABC):
         for split_message in split_messages[1:]:
             if len(split_message) <= 1:
                 continue
+            elif split_message[1] == "":
+                battle.parse_message(split_message)
             elif split_message[1] in self.MESSAGES_TO_IGNORE:
                 pass
             elif split_message[1] == "request":

--- a/unit_tests/environment/test_observation.py
+++ b/unit_tests/environment/test_observation.py
@@ -35,6 +35,7 @@ def test_observation(example_request):
     battle.parse_message(["", "-weather", "RainyDay"])
     battle.parse_message(["", "turn", "3"])
     battle.parse_message(["", "-weather", "SunnyDay"])
+    battle.parse_message(["", ""])
     battle.tied()
 
     # Check all attributes of Observation, as well as if it updates the battle states
@@ -64,6 +65,7 @@ def test_observation(example_request):
     assert Weather.SANDSTORM not in battle.observations[3].weather
 
     assert battle.observations[3].team != battle.observations[2].team
+    assert ["", ""] in battle.observations[3].events
 
 
 def test_observed_pokemon(example_request):


### PR DESCRIPTION
In Poke-env showdown protocol, empty events are used to track where we are in a turn state ([singles example](https://github.com/pkmn/stats/blob/main/anon/src/testdata/anon.json#L427), [doubles example](https://github.com/pkmn/stats/blob/main/stats/src/test/testdata/logs/gen6doublesou/log.1.json)), which are both useful to parsers and LLMs.

This change is quite small -- it allows for us to record empty events in observations.events so that any AI/model can better track what "chapter" of the turn we're in.