### PR TITLE
Added Effect Handling, and reordered a set for lint

### DIFF
--- a/src/poke_env/environment/abstract_battle.py
+++ b/src/poke_env/environment/abstract_battle.py
@@ -47,6 +47,7 @@ class AbstractBattle(ABC):
         "gametype",
         "html",
         "immune",
+        "inactiveoff",
         "init",
         "j",
         "join",
@@ -64,7 +65,6 @@ class AbstractBattle(ABC):
         "uhtml",
         "zbroken",
         "",
-        "inactiveoff",
     }
 
     __slots__ = (

--- a/src/poke_env/environment/effect.py
+++ b/src/poke_env/environment/effect.py
@@ -300,6 +300,22 @@ class Effect(Enum):
         return self in _PROTECT_BREAKING_EFFECTS
 
     @property
+    def ends_on_switch(self) -> bool:
+        """
+        :return: Whether this effect ends when the pokemon switches out.
+        :rtype: bool
+        """
+        return self.is_volatile_status or self in _ENDS_ON_SWITCH_EFFECTS
+
+    @property
+    def ends_on_turn(self) -> bool:
+        """
+        :return: Whether this effect ends at the end of the turn.
+        :rtype: bool
+        """
+        return self in _ENDS_ON_TURN_EFFECTS
+
+    @property
     def is_turn_countable(self) -> bool:
         """
         :return: Whether it is useful to keep track of the number of turns this effect
@@ -686,6 +702,42 @@ _TURN_COUNTER_EFFECTS: Set[Effect] = {
     Effect.UPROAR,
     Effect.WHIRLPOOL,
     Effect.WRAP,
+}
+
+_ENDS_ON_MOVE_EFFECTS = {
+    Effect.GLAIVE_RUSH,
+    Effect.CHARGE,
+}
+
+_ENDS_ON_SWITCH_EFFECTS = {
+    Effect.MIND_READER,
+    Effect.MUMMY,
+    Effect.SPEED_SWAP,
+}
+
+_ENDS_ON_TURN_EFFECTS = {
+    Effect.AFTER_YOU,
+    Effect.BANEFUL_BUNKER,
+    Effect.BURNING_BULWARK,
+    Effect.CRAFTY_SHIELD,
+    Effect.FEINT,
+    Effect.FLINCH,
+    Effect.FOLLOW_ME,
+    Effect.KINGS_SHIELD,
+    Effect.CUSTAP_BERRY,
+    Effect.MIND_READER,
+    Effect.MAGIC_COAT,
+    Effect.OBSTRUCT,
+    Effect.PROTECT,
+    Effect.QUASH,
+    Effect.QUICK_CLAW,
+    Effect.QUICK_DRAW,
+    Effect.QUICK_GUARD,
+    Effect.RAGE_POWDER,
+    Effect.ROOST,
+    Effect.SPIKY_SHIELD,
+    Effect.SPOTLIGHT,
+    Effect.WIDE_GUARD,
 }
 
 _ACTION_COUNTER_EFFECTS: Set[Effect] = {Effect.RAGE, Effect.STOCKPILE}

--- a/unit_tests/environment/test_enumerations.py
+++ b/unit_tests/environment/test_enumerations.py
@@ -7,6 +7,7 @@ from poke_env.environment import (
     Field,
     Move,
     MoveCategory,
+    Pokemon,
     PokemonGender,
     SideCondition,
     Status,
@@ -88,6 +89,36 @@ def test_effect_build():
                 or effect.is_from_item
                 or effect.is_from_move
             )
+
+
+def test_effect_end():
+    furret = Pokemon(gen=9, species="furret")
+    furret._effects = {
+        Effect.GLAIVE_RUSH: 1,
+        Effect.CHARGE: 1,
+        Effect.QUASH: 1,
+        Effect.MUMMY: 1,
+    }
+    furret.moved("followme")
+
+    assert Effect.GLAIVE_RUSH not in furret.effects
+    assert Effect.CHARGE in furret.effects
+
+    furret.moved("zapcannon")
+    assert Effect.CHARGE not in furret.effects
+
+    # Test end on turn
+    furret.end_turn()
+    assert Effect.QUASH not in furret.effects
+
+    # Test end on switch
+    furret.switch_out()
+    assert Effect.MUMMY not in furret.effects
+
+    # Test the definition of Volatile Status
+    for effect in list(Effect):
+        if effect.is_volatile_status:
+            assert effect.ends_on_switch
 
 
 def test_field_str():


### PR DESCRIPTION
[Issue here](https://github.com/hsahovic/poke-env/issues/579)

This just removes Effects when they silently get removed in the true battle state, but Showdown doesn't send you a log. Like all effects, testing is quite manual and maintenance is hard given that each effect is typically a unique edge-case.

However, this is 95% there and unblocks reverse speed/damage calculation

I also reordered items added to a set in abstract_battle to be consistent