### PR TITLE
Added further Effects handling from Showdown parsing and fainting

### DIFF
--- a/src/poke_env/environment/abstract_battle.py
+++ b/src/poke_env/environment/abstract_battle.py
@@ -32,7 +32,6 @@ class AbstractBattle(ABC):
         "-ohko",
         "-resisted",
         "-singlemove",
-        "-singleturn",
         "-supereffective",
         "-waiting",
         "-zbroken",
@@ -705,6 +704,9 @@ class AbstractBattle(ABC):
         elif split_message[1] == "-sidestart":
             side, condition = split_message[2:4]
             self._side_start(side, condition)
+        elif split_message[1] in ["-singleturn", "-singlemove"]:
+            pokemon, effect = split_message[2:4]
+            self.get_pokemon(pokemon).start_effect(effect.replace("move: ", ""))
         elif split_message[1] == "-swapboost":
             source, target, stats = split_message[2:5]
             source = self.get_pokemon(source)

--- a/src/poke_env/environment/pokemon.py
+++ b/src/poke_env/environment/pokemon.py
@@ -225,6 +225,7 @@ class Pokemon:
     def faint(self):
         self._current_hp = 0
         self._status = Status.FNT
+        self._effects = {}
 
     def forme_change(self, species: str):
         species = species.split(",")[0]

--- a/unit_tests/environment/test_battle.py
+++ b/unit_tests/environment/test_battle.py
@@ -324,6 +324,11 @@ def test_battle_request_and_interactions(example_request):
     for stat, boost in battle.opponent_active_pokemon.boosts.items():
         assert boost == -boosts_before_invertion[stat]
 
+    battle.parse_message(["", "-singleturn", "p1: Tyranitar", "move: Rage Powder"])
+    assert Effect.RAGE_POWDER in battle.opponent_active_pokemon.effects
+    battle.end_turn(1)
+    assert Effect.RAGE_POWDER not in battle.opponent_active_pokemon.effects
+
     battle.parse_message(
         [
             "",

--- a/unit_tests/environment/test_enumerations.py
+++ b/unit_tests/environment/test_enumerations.py
@@ -120,6 +120,11 @@ def test_effect_end():
         if effect.is_volatile_status:
             assert effect.ends_on_switch
 
+    furret.switch_in()
+    furret.start_effect("feint")
+    furret.faint()
+    assert furret.effects == {}
+
 
 def test_field_str():
     assert str(Field["ELECTRIC_TERRAIN"])


### PR DESCRIPTION
We add three things:
1. Parsing of `-singlemove` ([showdown protocol](https://github.com/smogon/pokemon-showdown/blob/master/data/moves.ts#L8168) and `-singleturn` ([showdown protocol](https://github.com/smogon/pokemon-showdown/blob/master/data/moves.ts#L8867))
2. Effect Handling for when a pokemon faints (we should remove all effects since they are no longer relevant to the battle state)
3. Tests for these