### PR TITLE
Added proper handling for moves that create -singlemove effects in Sh…

### DIFF
--- a/src/poke_env/environment/abstract_battle.py
+++ b/src/poke_env/environment/abstract_battle.py
@@ -31,7 +31,6 @@ class AbstractBattle(ABC):
         "-nothing",
         "-ohko",
         "-resisted",
-        "-singlemove",
         "-supereffective",
         "-waiting",
         "-zbroken",

--- a/unit_tests/environment/test_battle.py
+++ b/unit_tests/environment/test_battle.py
@@ -330,6 +330,11 @@ def test_battle_request_and_interactions(example_request):
     assert Effect.RAGE_POWDER not in battle.opponent_active_pokemon.effects
 
     battle.parse_message(
+        ["", "-singlemove", "p1: Tyranitar", "Glaive Rush", "[silent]"]
+    )
+    assert Effect.GLAIVE_RUSH in battle.opponent_active_pokemon.effects
+
+    battle.parse_message(
         [
             "",
             "-item",


### PR DESCRIPTION
Remove "-singlemove" from MESSAGES_TO_IGNORE so that we successfully parse moves that [generate this message](https://github.com/smogon/pokemon-showdown/blob/4cece4ee981d90b26c53ff28a0da9d0def84486b/data/moves.ts) via showdown.

Also added test verifying that these messages are properly parsed and added into the AbstractBattle object