### PR TITLE
Replaced rqid with Last Request

### DIFF
--- a/src/poke_env/environment/abstract_battle.py
+++ b/src/poke_env/environment/abstract_battle.py
@@ -84,6 +84,7 @@ class AbstractBattle(ABC):
         "_format",
         "_gen",
         "in_team_preview",
+        "_last_request",
         "_max_team_size",
         "_maybe_trapped",
         "_move_on_next_request",
@@ -103,7 +104,6 @@ class AbstractBattle(ABC):
         "_rating",
         "_reconnected",
         "_replay_data",
-        "_rqid",
         "rules",
         "_reviving",
         "_save_replays",
@@ -159,7 +159,7 @@ class AbstractBattle(ABC):
         # Battle state attributes
         self._dynamax_turn: Optional[int] = None
         self._finished: bool = False
-        self._rqid = 0
+        self._last_request: Dict[str, Any] = {}
         self.rules: List[str] = []
         self._turn: int = 0
         self._opponent_can_terrastallize: bool = True
@@ -1001,6 +1001,17 @@ class AbstractBattle(ABC):
         return self._gen
 
     @property
+    def last_request(self) -> Dict[str, Any]:
+        """
+        The last request received from the server. This allows players to track
+            rqid and also maintain parallel battle copies for search/inference
+
+        :return: The last request.
+        :rtype: Dict[str, Any]
+        """
+        return self._last_request
+
+    @property
     def lost(self) -> Optional[bool]:
         """
         :return: If the battle is finished, a boolean indicating whether the battle is
@@ -1175,16 +1186,6 @@ class AbstractBattle(ABC):
         :rtype: int, optional
         """
         return self._opponent_rating
-
-    @property
-    def rqid(self) -> int:
-        """
-        Should not be used.
-
-        :return: The last request's rqid.
-        :rtype: int
-        """
-        return self._rqid
 
     @property
     def side_conditions(self) -> Dict[SideCondition, int]:

--- a/src/poke_env/environment/battle.py
+++ b/src/poke_env/environment/battle.py
@@ -84,8 +84,7 @@ class Battle(AbstractBattle):
         if self._force_switch:
             self._move_on_next_request = True
 
-        if request["rqid"]:
-            self._rqid = max(self._rqid, request["rqid"])
+        self._last_request = request
 
         if request.get("teamPreview", False):
             self._teampreview = True

--- a/src/poke_env/environment/double_battle.py
+++ b/src/poke_env/environment/double_battle.py
@@ -117,8 +117,7 @@ class DoubleBattle(AbstractBattle):
         if any(self._force_switch):
             self._move_on_next_request = True
 
-        if request["rqid"]:
-            self._rqid = max(self._rqid, request["rqid"])
+        self._last_request = request
 
         if request.get("teamPreview", False):
             self._teampreview = True

--- a/unit_tests/environment/test_double_battle.py
+++ b/unit_tests/environment/test_double_battle.py
@@ -270,6 +270,8 @@ def test_one_mon_left_in_double_battles_results_in_available_move_in_the_correct
     battle.parse_message(["", "turn", "1"])
 
     battle.parse_request(request)
+    assert battle.last_request == request
+
     battle.parse_message(
         ["", "swap", "p1b: Cresselia", "0", "[from] move: Ally Switch"]
     )


### PR DESCRIPTION
Mentioned in https://github.com/hsahovic/poke-env/issues/624

`rqid` is labeled as a field to not be trusted (according to the documentation). I replace `AbstractBattle.rqid` with `AbstractBattle.last_request` that holds `rqid` via `AbstractBattle.last_request["rqid"]`, and also the other latest information returned by Showdown in the last request.

This is helpful to keep parallel battle states running (by passing other `Battle` objects the same requests via `parse_request`, which is useful in two scenarios:
1. When an agent wants to track a separate battle state for inference (eg make guesses about a battle and embed that battle state instead of tampering with the pristine Showdown-only one)
2. When an agent wants to track a separate abstracted battle state for search (eg if we integrate with another engine)