### PR TITLE
Added correct interpretation of hospitality showdown protocol

### DIFF
--- a/src/poke_env/environment/abstract_battle.py
+++ b/src/poke_env/environment/abstract_battle.py
@@ -308,10 +308,15 @@ class AbstractBattle(ABC):
         #   it implies the ability is from the opposite side
         # Example:
         #   |-heal|p2a: Quagsire|100/100|[from] ability: Water Absorb|[of] p1a: Genesect
+        #   |-heal|p2b: Excadrill|100/100|from] ability: Hospitality|[of] p2a: Sinistcha
         if len(split_message) == 6 and split_message[4].startswith("[from] ability:"):
-            ability = split_message[4].split("ability:")[-1]
-            pkmn = split_message[2]
-            self.get_pokemon(pkmn).ability = to_id_str(ability)
+            ability = to_id_str(split_message[4].split("ability:")[-1])
+            if ability == "hospitality":
+                pkmn = split_message[5].replace("[of] ", "").strip()
+                self.get_pokemon(pkmn).ability = ability
+            else:
+                pkmn = split_message[2]
+                self.get_pokemon(pkmn).ability = ability
 
     @abstractmethod
     def end_illusion(self, pokemon_name: str, details: str):

--- a/unit_tests/environment/test_double_battle.py
+++ b/unit_tests/environment/test_double_battle.py
@@ -111,6 +111,40 @@ def test_battle_request_parsing_and_interactions(example_doubles_request):
     assert all(battle.opponent_can_dynamax)
 
 
+def test_check_heal_message_for_ability():
+    logger = MagicMock()
+    battle = DoubleBattle("tag", "username", logger, gen=8)
+    battle.player_role = "p1"
+
+    # Add two active opponent pokemon
+    battle.parse_message(["", "switch", "p2a: Furret", "Furret, L50, F", "100/100"])
+    battle.parse_message(["", "switch", "p2b: Sentret", "Sentret, L50, F", "100/100"])
+
+    battle.parse_message(
+        [
+            "",
+            "-heal",
+            "p2a: Furret",
+            "100/100",
+            "[from] ability: Water Absorb",
+            "[of] p2b: Sentret",
+        ]
+    )
+    assert battle.opponent_team["p2: Furret"].ability == "waterabsorb"
+
+    battle.parse_message(
+        [
+            "",
+            "-heal",
+            "p2b: Furret",
+            "100/100",
+            "[from] ability: Hospitality",
+            "[of] p2a: Sentret",
+        ]
+    )
+    assert battle.opponent_team["p2: Sentret"].ability == "hospitality"
+
+
 def test_get_possible_showdown_targets(example_doubles_request):
     logger = MagicMock()
     battle = DoubleBattle("tag", "username", logger, gen=8)


### PR DESCRIPTION
Hospitality protocol is wonky in Showdown and requires special parsing; right now, poke-env gives the wrong pokemon the ability (eg incorrectly parses hospitality messages). This is obvious in the following two showdown events, where the ability should be assigned to Quagsire in the first case and Sinistcha in the second.
```
|-heal|p2a: Quagsire|100/100|[from] ability: Water Absorb|[of] p1a: Genesect
|-heal|p2b: Excadrill|100/100|from] ability: Hospitality|[of] p2a: Sinistcha
```

Also, mentioned here: https://github.com/hsahovic/poke-env/issues/626