### PR TITLE
Added correct handling for pledge moves

### DIFF
--- a/src/poke_env/environment/abstract_battle.py
+++ b/src/poke_env/environment/abstract_battle.py
@@ -443,6 +443,8 @@ class AbstractBattle(ABC):
                     reveal_other_move = True
                 elif override_move in {"Copycat", "Metronome", "Nature Power"}:
                     pass
+                elif override_move in {"Grass Pledge", "Water Pledge", "Fire Pledge"}:
+                    override_move = None
                 elif self.logger is not None:
                     self.logger.warning(
                         "Unmanaged [from]move message received - move %s in cleaned up "

--- a/unit_tests/environment/test_double_battle.py
+++ b/unit_tests/environment/test_double_battle.py
@@ -307,3 +307,43 @@ def test_gen_and_format(example_doubles_logs):
     assert battle.gen == 6
     assert battle.battle_tag == "tag"
     assert battle.format == "gen6doublesou"
+
+
+def test_pledge_moves():
+    battle = DoubleBattle("tag", "username", MagicMock(), gen=8)
+    battle.player_role = "p2"
+
+    events = [
+        ["", "switch", "p1a: Indeedee", "Indeedee-F, L50, F", "100/100"],
+        ["", "switch", "p1b: Hatterene", "Hatterene, L50, F", "100/100"],
+        ["", "switch", "p2a: Primarina", "Primarina, L50, F, shiny", "169/169"],
+        ["", "switch", "p2b: Decidueye", "Decidueye-Hisui, L50, F, shiny", "171/171"],
+        ["", ""],
+        ["", "-terastallize", "p2a: Primarina", "Poison"],
+        ["", "-terastallize", "p1a: Indeedee", "Grass"],
+        ["", "move", "p2b: Decidueye", "Grass Pledge", "p1a: Indeedee"],
+        ["", "-waiting", "p2b: Decidueye", "p2a: Primarina"],
+        [
+            "",
+            "move",
+            "p2a: Primarina",
+            "Water Pledge",
+            "p1b: Hatterene",
+            "[from]move: Grass Pledge",
+        ],
+        ["", "-combine"],
+        ["", "-damage", "p1b: Hatterene", "0 fnt"],
+        ["", "-sidestart", "p1: cloverspsyspamsep", "Grass Pledge"],
+        ["", "faint", "p1b: Hatterene"],
+        ["", "-damage", "p2a: Primarina", "153/169", "[from] item: Life Orb"],
+        ["", "move", "p1a: Indeedee", "Psychic", "p1: Hatterene", "[notarget]"],
+        ["", "-fail", "p1a: Indeedee"],
+        ["", ""],
+        ["", "upkeep"],
+    ]
+
+    for event in events:
+        battle.parse_message(event)
+
+    assert "grasspledge" not in battle.team["p2: Primarina"].moves
+    assert "waterpledge" in battle.team["p2: Primarina"].moves

--- a/unit_tests/environment/test_double_battle.py
+++ b/unit_tests/environment/test_double_battle.py
@@ -319,8 +319,6 @@ def test_pledge_moves():
         ["", "switch", "p2a: Primarina", "Primarina, L50, F, shiny", "169/169"],
         ["", "switch", "p2b: Decidueye", "Decidueye-Hisui, L50, F, shiny", "171/171"],
         ["", ""],
-        ["", "-terastallize", "p2a: Primarina", "Poison"],
-        ["", "-terastallize", "p1a: Indeedee", "Grass"],
         ["", "move", "p2b: Decidueye", "Grass Pledge", "p1a: Indeedee"],
         ["", "-waiting", "p2b: Decidueye", "p2a: Primarina"],
         [
@@ -334,12 +332,6 @@ def test_pledge_moves():
         ["", "-combine"],
         ["", "-damage", "p1b: Hatterene", "0 fnt"],
         ["", "-sidestart", "p1: cloverspsyspamsep", "Grass Pledge"],
-        ["", "faint", "p1b: Hatterene"],
-        ["", "-damage", "p2a: Primarina", "153/169", "[from] item: Life Orb"],
-        ["", "move", "p1a: Indeedee", "Psychic", "p1: Hatterene", "[notarget]"],
-        ["", "-fail", "p1a: Indeedee"],
-        ["", ""],
-        ["", "upkeep"],
     ]
 
     for event in events:


### PR DESCRIPTION
Right now, pledge moves are incorrectly handled and overrode, so that if Piplup used Water Pledge and Cyndaquil followed up with Fire Pledge, we would set Cyndaquil's move as Water Pledge. This is a problem when we update the mon with a request, because there'd be a conflict of moves and it will raise a Error

Mentioned here: https://github.com/hsahovic/poke-env/issues/628