### PR TITLE
Fixed name and teambuilder handling

### DIFF
--- a/fixture_data/example_doubles_request.json
+++ b/fixture_data/example_doubles_request.json
@@ -102,7 +102,7 @@
                 "baseAbility": "screencleaner",
                 "condition": "250/250",
                 "details": "Mr. Rime, L77, M",
-                "ident": "p1: Mr. Rime",
+                "ident": "p1: Nickname",
                 "item": "sitrusberry",
                 "moves": ["psychic", "rapidspin", "freezedry", "slackoff"],
                 "pokeball": "pokeball",

--- a/src/poke_env/environment/abstract_battle.py
+++ b/src/poke_env/environment/abstract_battle.py
@@ -219,6 +219,7 @@ class AbstractBattle(ABC):
             return self._opponent_team[identifier]
 
         player_role = identifier[:2]
+        name = identifier[3:].strip()
         is_mine = player_role == self._player_role
 
         if is_mine or force_self_team:
@@ -238,12 +239,14 @@ class AbstractBattle(ABC):
             )
 
         if request:
-            team[identifier] = Pokemon(request_pokemon=request, gen=self._data.gen)
+            team[identifier] = Pokemon(
+                request_pokemon=request, name=name, gen=self._data.gen
+            )
         elif details:
-            team[identifier] = Pokemon(details=details, gen=self._data.gen)
+            team[identifier] = Pokemon(details=details, name=name, gen=self._data.gen)
         else:
             species = identifier[4:]
-            team[identifier] = Pokemon(species=species, gen=self._data.gen)
+            team[identifier] = Pokemon(species=species, name=name, gen=self._data.gen)
 
         return team[identifier]
 

--- a/unit_tests/environment/test_double_battle.py
+++ b/unit_tests/environment/test_double_battle.py
@@ -45,7 +45,7 @@ def test_battle_request_parsing_and_interactions(example_doubles_request):
     assert their_first_active is None and their_second_active is None
     assert isinstance(mr_rime, Pokemon)
     assert isinstance(klinklang, Pokemon)
-    assert battle.get_pokemon("p1: Mr. Rime") == mr_rime
+    assert battle.get_pokemon("p1: Nickname") == mr_rime
     assert battle.get_pokemon("p1: Klinklang") == klinklang
 
     assert set(battle.available_moves[0]) == set(

--- a/unit_tests/environment/test_pokemon.py
+++ b/unit_tests/environment/test_pokemon.py
@@ -1,4 +1,6 @@
-from poke_env.environment import Move, Pokemon, PokemonGender, PokemonType
+from unittest.mock import MagicMock
+
+from poke_env.environment import DoubleBattle, Move, Pokemon, PokemonGender, PokemonType
 from poke_env.stats import _raw_hp, _raw_stat
 from poke_env.teambuilder.teambuilder import Teambuilder
 
@@ -214,20 +216,59 @@ def test_teambuilder(showdown_format_teams):
     )
     mon = Pokemon(9, teambuilder=tb_mons[0])
     assert mon
-    assert mon.name == "Weezing-Galar"
+    assert mon.name == "Weezing"
     assert mon.level == 50
     assert mon.ability == "neutralizinggas"
     assert mon.item is None
     assert list(mon.moves.keys()) == ["clearsmog"]
     assert mon.tera_type is None
+    assert mon.stats == {
+        "hp": 140,
+        "atk": 110,
+        "def": 140,
+        "spa": 105,
+        "spd": 90,
+        "spe": 80,
+    }
 
 
-def test_name():
+def test_name(example_doubles_request):
     charizard = Pokemon(species="charizard", gen=8)
     assert charizard.name == "Charizard"
 
     chiyu = Pokemon(species="chiyu", gen=9)
     assert chiyu.name == "Chi-Yu"
+
+    furret = Pokemon(species="furret", name="Nickname", gen=9)
+    assert furret.name == "Nickname"
+
+    calyrexshadow = Pokemon(species="calyrexshadow", gen=9)
+    assert calyrexshadow.name == "Calyrex"
+
+    zamazenta = Pokemon(species="zamazentacrowned", gen=9)
+    assert zamazenta.name == "Zamazenta"
+
+    logger = MagicMock()
+    battle = DoubleBattle("tag", "username", logger, gen=8)
+    battle.parse_request(example_doubles_request)
+
+    mon = battle.team["p1: Nickname"]
+    assert mon.name == "Nickname"
+    assert mon.species == "mrrime"
+
+    tb_mons = Teambuilder.parse_showdown_team(
+        "Weezing-Galar\nAbility: Neutralizing Gas\nLevel: 50\n- Clear Smog"
+    )
+    mon = Pokemon(9, teambuilder=tb_mons[0])
+    assert mon.species == "weezinggalar"
+    assert mon.name == "Weezing"
+
+    tb_mons = Teambuilder.parse_showdown_team(
+        "Nickname (Zamazenta-Crowned)\nAbility: Dauntless Shield\nLevel: 50\n- Behemoth Bash"
+    )
+    mon = Pokemon(9, teambuilder=tb_mons[0])
+    assert mon.species == "zamazentacrowned"
+    assert mon.name == "Nickname"
 
 
 def test_stats(example_request, showdown_format_teams):


### PR DESCRIPTION
Did two things:
1. Added `name` property to `Pokemon` so that it can store their own Showdown identifiers; it is an optional argument that can be passed, which is typically passed through a request
2. Fixed the reliability of Teambuilder instantiation for `Pokemon`, where a `nature` isn't needed to be specified. In the old setup, we wouldn't calculate the stats because we didn't have the nature. But in reality, Showdown assumes no nature is `"serious"`, and so we correct for this to ensure we have stats calculated for any mon that is bulit via teambuilder'

Added appropriate testing

Mentioned here: https://github.com/hsahovic/poke-env/issues/625