### PR TITLE
Added current_observation property to AbstractBattle

### DIFF
--- a/src/poke_env/environment/abstract_battle.py
+++ b/src/poke_env/environment/abstract_battle.py
@@ -952,6 +952,16 @@ class AbstractBattle(ABC):
         pass
 
     @property
+    def current_observation(self) -> Observation:
+        """
+        :return: The current observation of the current turn in the Battle.
+            Most useful for when a force_switch triggers in the middle of a
+            turn, and our player has to return an action.
+        :rtype: Observation
+        """
+        return self._current_observation
+
+    @property
     def dynamax_turns_left(self) -> Optional[int]:
         """
         :return: How many turns of dynamax are left. None if dynamax is not active

--- a/unit_tests/environment/test_double_battle.py
+++ b/unit_tests/environment/test_double_battle.py
@@ -110,6 +110,9 @@ def test_battle_request_parsing_and_interactions(example_doubles_request):
 
     assert all(battle.opponent_can_dynamax)
 
+    assert battle.current_observation
+    assert battle.current_observation.events[0] == ["", "swap", "p1b: Klinklang", ""]
+
 
 def test_get_possible_showdown_targets(example_doubles_request):
     logger = MagicMock()


### PR DESCRIPTION
This is important for battle parsing when there's a force switch; an agent needs to be able to access the logs in the current turn to assess the battle state and understand what it needs to do next.

Mentioned here: https://github.com/hsahovic/poke-env/issues/630