### PR TITLE
Added terastarstorm support for doubles

### DIFF
--- a/src/poke_env/environment/double_battle.py
+++ b/src/poke_env/environment/double_battle.py
@@ -294,6 +294,8 @@ class DoubleBattle(AbstractBattle):
             PokemonType.GHOST not in pokemon.types
         ):  # fixing target for Curse
             return [self.EMPTY_TARGET_POSITION]
+        elif move.id == "terastarstorm" and pokemon.type_1 == PokemonType.STELLAR:
+            targets = [self.EMPTY_TARGET_POSITION]
         else:
             targets = {
                 Target.from_showdown_message("adjacentAlly"): [ally_position],

--- a/unit_tests/environment/test_double_battle.py
+++ b/unit_tests/environment/test_double_battle.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from poke_env.environment import DoubleBattle, Pokemon
+from poke_env.environment import DoubleBattle, Move, Pokemon
 
 
 def test_battle_request_parsing(example_doubles_request):
@@ -131,6 +131,13 @@ def test_get_possible_showdown_targets(example_doubles_request):
         2,
     ]
     assert battle.get_possible_showdown_targets(slackoff, mr_rime, dynamax=True) == [0]
+
+    # Override last request with terastarstorm for Mr. Rime
+    terastarstorm = Move("terastarstorm", gen=9)
+    battle._available_moves = [[terastarstorm], []]
+    assert battle.get_possible_showdown_targets(terastarstorm, mr_rime) == [-2, 1, 2]
+    mr_rime.terastallize("stellar")
+    assert battle.get_possible_showdown_targets(terastarstorm, mr_rime) == [0]
 
 
 def test_to_showdown_target(example_doubles_request):


### PR DESCRIPTION
Like `Curse`, `Tera Star Storm` has different targets depending on the state of the `Battle` and the `Pokemon` using it. Unfortunately, Showdown implemented it in a way that is not like `Expanding Force` (which turns to spread in `Psychic Terrain`) where targeting choices are overrode, but instead throws `[Error]`s when incorrect targets or chosen. This is a small patch to address that error.

Mentioned here: https://github.com/hsahovic/poke-env/issues/631