### PR TITLE
Adding support for Temporary Types and Abilities

### DIFF
--- a/src/poke_env/environment/abstract_battle.py
+++ b/src/poke_env/environment/abstract_battle.py
@@ -676,10 +676,7 @@ class AbstractBattle(ABC):
             self.get_pokemon(pokemon).end_effect(effect)
         elif event[1] == "-endability":
             pokemon = event[2]
-            if len(event) > 4 and event[4].startswith("[from] move:"):
-                self.get_pokemon(pokemon).set_temporary_ability(None)
-            else:
-                self.get_pokemon(pokemon).ability = None
+            self.get_pokemon(pokemon).set_temporary_ability(None)
         elif event[1] == "-enditem":
             pokemon, item = event[2:4]
             self.get_pokemon(pokemon).end_item(item)

--- a/src/poke_env/environment/abstract_battle.py
+++ b/src/poke_env/environment/abstract_battle.py
@@ -610,7 +610,10 @@ class AbstractBattle(ABC):
             self.get_pokemon(pokemon).boost(stat, -int(amount))
         elif event[1] == "-ability":
             pokemon, ability = event[2:4]
-            self.get_pokemon(pokemon).ability = ability
+            if len(event) > 4 and event[4].startswith("[from] move:"):
+                self.get_pokemon(pokemon).set_temporary_ability(ability)
+            else:
+                self.get_pokemon(pokemon).ability = ability
         elif split_message[1] == "-start":
             pokemon, effect = event[2:4]
             pokemon = self.get_pokemon(pokemon)
@@ -634,6 +637,8 @@ class AbstractBattle(ABC):
             target, effect = event[2:4]
             if target and effect == "move: Skill Swap":
                 self.get_pokemon(target).start_effect(effect, event[4:6])
+                actor = event[6].replace("[of] ", "")
+                self.get_pokemon(actor).set_temporary_ability(event[5])
             else:
                 self.get_pokemon(target).start_effect(effect)
         elif event[1] == "-status":
@@ -671,7 +676,10 @@ class AbstractBattle(ABC):
             self.get_pokemon(pokemon).end_effect(effect)
         elif event[1] == "-endability":
             pokemon = event[2]
-            self.get_pokemon(pokemon).ability = None
+            if len(event) > 4 and event[4].startswith("[from] move:"):
+                self.get_pokemon(pokemon).set_temporary_ability(None)
+            else:
+                self.get_pokemon(pokemon).ability = None
         elif event[1] == "-enditem":
             pokemon, item = event[2:4]
             self.get_pokemon(pokemon).end_item(item)

--- a/src/poke_env/environment/abstract_battle.py
+++ b/src/poke_env/environment/abstract_battle.py
@@ -611,10 +611,14 @@ class AbstractBattle(ABC):
         elif event[1] == "-ability":
             pokemon, ability = event[2:4]
             self.get_pokemon(pokemon).ability = ability
-        elif event[1] == "-start":
+        elif split_message[1] == "-start":
             pokemon, effect = event[2:4]
-            pokemon = self.get_pokemon(pokemon)  # type: ignore
-            pokemon.start_effect(effect)  # type: ignore
+            pokemon = self.get_pokemon(pokemon)
+
+            if effect == "typechange":
+                pokemon.start_effect(effect, details=event[4])
+            else:
+                pokemon.start_effect(effect)
 
             if pokemon.is_dynamaxed:  # type: ignore
                 if pokemon in set(self.team.values()) and self._dynamax_turn is None:
@@ -628,7 +632,9 @@ class AbstractBattle(ABC):
                     self.opponent_can_dynamax = False
         elif event[1] == "-activate":
             target, effect = event[2:4]
-            if target:
+            if target and effect == "move: Skill Swap":
+                self.get_pokemon(target).start_effect(effect, event[4:6])
+            else:
                 self.get_pokemon(target).start_effect(effect)
         elif event[1] == "-status":
             pokemon, status = event[2:4]

--- a/src/poke_env/environment/pokemon.py
+++ b/src/poke_env/environment/pokemon.py
@@ -12,6 +12,8 @@ from poke_env.environment.z_crystal import Z_CRYSTAL
 from poke_env.stats import compute_raw_stats
 from poke_env.teambuilder.teambuilder_pokemon import TeambuilderPokemon
 
+_NO_ABILITY = "NO_ABILITY"
+
 
 class Pokemon:
     __slots__ = (
@@ -386,7 +388,7 @@ class Pokemon:
         if ability is not None:
             self._temporary_ability = to_id_str(ability)
         else:
-            self._temporary_ability = None
+            self._temporary_ability = _NO_ABILITY
 
     def start_effect(self, effect_str: str, details: Optional[Any] = None):
         effect = Effect.from_showdown_message(effect_str)
@@ -673,10 +675,12 @@ class Pokemon:
     @property
     def ability(self) -> Optional[str]:
         """
-        :return: The pokemon's ability. None if unknown.
+        :return: The pokemon's ability. None if unknown or removed.
         :rtype: str, optional
         """
-        if self._temporary_ability is not None:
+        if self._temporary_ability == _NO_ABILITY:
+            return None
+        elif self._temporary_ability is not None:
             return self._temporary_ability
         else:
             return self._ability

--- a/unit_tests/environment/test_battle.py
+++ b/unit_tests/environment/test_battle.py
@@ -33,10 +33,10 @@ def test_battle_get_pokemon():
     assert "p1: hydreigon" in battle.opponent_team
 
     assert battle.get_pokemon("p2: tapufini").species == "tapufini"
-    assert battle.get_pokemon("p2: tapubulu").types == (
+    assert battle.get_pokemon("p2: tapubulu").types == [
         PokemonType.GRASS,
         PokemonType.FAIRY,
-    )
+    ]
     assert battle.get_pokemon("p2: tapulele").base_stats == {
         "atk": 85,
         "def": 75,
@@ -576,9 +576,7 @@ def test_battle_request_and_interactions(example_request):
     # Test temporary types and abilities
     battle.active_pokemon._ability = "prismarmor"
     battle.opponent_active_pokemon._ability = "desolateland"
-    battle.parse_message(
-        ["", "move", "p2a: Necrozma", "Worry Seed", "p1a: Groudon"]
-    )
+    battle.parse_message(["", "move", "p2a: Necrozma", "Worry Seed", "p1a: Groudon"])
     battle.parse_message(
         ["", "-endability", "p1a: Groudon", "Desolate Land", "[from] move: Worry Seed"]
     )
@@ -591,11 +589,17 @@ def test_battle_request_and_interactions(example_request):
     groudon.switch_in()
     assert groudon.ability == "desolateland"
 
+    battle.parse_message(["", "move", "p1a: Groudon", "Skill Swap", "p2a: Necrozma"])
     battle.parse_message(
-        ["", "move", "p1a: Groudon", "Skill Swap", "p2a: Necrozma"]
-    )
-    battle.parse_message(
-        ["", "-activate", "p1a: Groudon", "move: Skill Swap", "Prism Armor", "Desolate Land", "[of] p2a: Glimmora"]
+        [
+            "",
+            "-activate",
+            "p1a: Groudon",
+            "move: Skill Swap",
+            "Prism Armor",
+            "Desolate Land",
+            "[of] p2a: Necrozma",
+        ]
     )
     assert battle.opponent_active_pokemon.ability == "prismarmor"
     assert battle.active_pokemon.ability == "desolateland"
@@ -603,42 +607,36 @@ def test_battle_request_and_interactions(example_request):
     groudon.switch_out()
     assert groudon.ability == "desolateland"
 
-    pawmot = battle.opponent_active_pokemon
-    assert pawmot.type_1 == PokemonType.ELECTRIC
-    assert pawmot.type_2 == PokemonType.FIGHTING
-    assert pawmot.types == [PokemonType.ELECTRIC, PokemonType.FIGHTING]
-    battle.parse_message(["", "switch", "p1: Pawmot", "Pawmot, L82", "100/100"])
-    battle.parse_message(
-        ["", "move", "p1a: Pawmot", "Double Shock", "p2a: Necrozma"]
-    )
-    battle.parse_message(["", "-damage", "p2a: Necrozma", "87/100"])
-    battle.parse_message(
-        ["", "-start", "p1a: Pawmot", "typechange", "???/Fighting", "[from] move: Double Shock"]
-    )
-    
-    assert pawmot.type_1 == PokemonType.THREE_QUESTION_MARKS
-    assert pawmot.type_2 == PokemonType.FIGHTING
-    assert pawmot.types == [PokemonType.THREE_QUESTION_MARKS, PokemonType.FIGHTING]
-    pawmot.switch_out()
-    pawmot.switch_in()
-    assert pawmot.type_1 == PokemonType.ELECTRIC
-    assert pawmot.type_2 == PokemonType.FIGHTING
-    assert pawmot.types == [PokemonType.ELECTRIC, PokemonType.FIGHTING]
+    battle.parse_message(["", "switch", "p1a: Ho-oh", "Ho-oh, L82", "100/100"])
+    hooh = battle.opponent_active_pokemon
+    assert hooh.type_1 == PokemonType.FIRE
+    assert hooh.type_2 == PokemonType.FLYING
+    assert hooh.types == [PokemonType.FIRE, PokemonType.FLYING]
 
+    battle.parse_message(["", "move", "p1a: Ho-oh", "Burn Up", "p2a: Necrozma"])
     battle.parse_message(
-        ["", "move", "p2a: Necrozma", "Soak", "p1a: Pawmot"]
+        ["", "-start", "p1a: Ho-oh", "typechange", "???/Flying", "[from] move: Burn Up"]
     )
-    battle.parse_message(
-        ["", "-start", "p1a: Pawmot", "typechange", "Water"]
-    )
-    assert pawmot.type_1 == PokemonType.WATER
-    assert pawmot.type_2 == None
-    assert pawmot.types == [PokemonType.THREE_QUESTION_MARKS]
-    pawmot.switch_out()
-    pawmot.switch_in()
-    assert pawmot.type_1 == PokemonType.ELECTRIC
-    assert pawmot.type_2 == PokemonType.FIGHTING
-    assert pawmot.types == [PokemonType.ELECTRIC, PokemonType.FIGHTING]
+
+    assert hooh.type_1 == PokemonType.THREE_QUESTION_MARKS
+    assert hooh.type_2 == PokemonType.FLYING
+    assert hooh.types == [PokemonType.THREE_QUESTION_MARKS, PokemonType.FLYING]
+    hooh.switch_out()
+    hooh.switch_in()
+    assert hooh.type_1 == PokemonType.FIRE
+    assert hooh.type_2 == PokemonType.FLYING
+    assert hooh.types == [PokemonType.FIRE, PokemonType.FLYING]
+
+    battle.parse_message(["", "move", "p2a: Necrozma", "Soak", "p1a: Ho-oh"])
+    battle.parse_message(["", "-start", "p1a: Ho-oh", "typechange", "Water"])
+    assert hooh.type_1 == PokemonType.WATER
+    assert hooh.type_2 is None
+    assert hooh.types == [PokemonType.WATER]
+    hooh.switch_out()
+    hooh.switch_in()
+    assert hooh.type_1 == PokemonType.FIRE
+    assert hooh.type_2 == PokemonType.FLYING
+    assert hooh.types == [PokemonType.FIRE, PokemonType.FLYING]
 
 
 def test_end_illusion():

--- a/unit_tests/environment/test_battle.py
+++ b/unit_tests/environment/test_battle.py
@@ -539,7 +539,12 @@ def test_battle_request_and_interactions(example_request):
         ]
     )
     assert battle.opponent_active_pokemon.ability == "waterabsorb"
-    battle.opponent_active_pokemon._ability = None
+    necrozma = battle.active_pokemon
+    groudon = battle.opponent_active_pokemon
+
+    necrozma.switch_out()
+    groudon.switch_in()
+    groudon._ability = None
 
     battle.parse_message(
         [
@@ -551,40 +556,42 @@ def test_battle_request_and_interactions(example_request):
             "[of] p1a: Groudon",
         ]
     )
-    assert battle.active_pokemon.ability == "waterabsorb"
+    assert necrozma.ability == "waterabsorb"
 
-    battle.active_pokemon.item = GenData.UNKNOWN_ITEM
+    necrozma.item = GenData.UNKNOWN_ITEM
     battle.parse_message(
         ["", "-heal", "p2a: Necrozma", "200/265", "[from] item: Leftovers"]
     )
-    assert battle.active_pokemon.item == "leftovers"
-    battle.active_pokemon.item = None
+    assert necrozma.item == "leftovers"
+    necrozma.item = None
 
-    battle.opponent_active_pokemon.item = GenData.UNKNOWN_ITEM
+    groudon.item = GenData.UNKNOWN_ITEM
     battle.parse_message(
         ["", "-heal", "p1a: Groudon", "200/265", "[from] item: Leftovers"]
     )
-    assert battle.opponent_active_pokemon.item == "leftovers"
-    battle.opponent_active_pokemon.item = None
+    assert groudon.item == "leftovers"
+    groudon.item = None
 
-    battle.opponent_active_pokemon.item = None
+    groudon.item = None
     battle.parse_message(
         ["", "-heal", "p1a: Groudon", "200/265", "[from] item: Sitrus Berry"]
     )
-    assert battle.opponent_active_pokemon.item is None
+    assert groudon.item is None
 
     # Test temporary types and abilities
-    battle.active_pokemon._ability = "prismarmor"
-    battle.opponent_active_pokemon._ability = "desolateland"
+
+    necrozma._ability = "prismarmor"
+    groudon._ability = "desolateland"
     battle.parse_message(["", "move", "p2a: Necrozma", "Worry Seed", "p1a: Groudon"])
+    assert groudon.ability == "desolateland"
     battle.parse_message(
         ["", "-endability", "p1a: Groudon", "Desolate Land", "[from] move: Worry Seed"]
     )
+    assert groudon.ability is None
     battle.parse_message(
         ["", "-ability", "p1a: Groudon", "Insomnia", "[from] move: Worry Seed"]
     )
-    assert battle.opponent_active_pokemon.ability == "insomnia"
-    groudon = battle.opponent_active_pokemon
+    assert groudon.ability == "insomnia"
     groudon.switch_out()
     groudon.switch_in()
     assert groudon.ability == "desolateland"
@@ -601,8 +608,8 @@ def test_battle_request_and_interactions(example_request):
             "[of] p2a: Necrozma",
         ]
     )
-    assert battle.opponent_active_pokemon.ability == "prismarmor"
-    assert battle.active_pokemon.ability == "desolateland"
+    assert groudon.ability == "prismarmor"
+    assert necrozma.ability == "desolateland"
     groudon.switch_in()
     groudon.switch_out()
     assert groudon.ability == "desolateland"

--- a/unit_tests/environment/test_pokemon.py
+++ b/unit_tests/environment/test_pokemon.py
@@ -337,5 +337,12 @@ def test_temporary():
     assert furret.type_2 is None
     assert furret.damage_multiplier(PokemonType.ICE) == 2
 
+    furret.set_temporary_ability("frisk")
+    assert furret.ability == "frisk"
+
+    furret.set_temporary_ability(None)
+    assert furret.ability is None
+
     furret.switch_out()
+    assert furret.ability == "adaptability"
     assert furret.types == [PokemonType.DRAGON]

--- a/unit_tests/environment/test_pokemon.py
+++ b/unit_tests/environment/test_pokemon.py
@@ -311,24 +311,31 @@ def test_stats(example_request, showdown_format_teams):
 
 def test_temporary():
     furret = Pokemon(species="furret", gen=8)
+    furret._ability = "adaptability"
+
     assert furret.types == [PokemonType.NORMAL]
-    assert furret.stab_multiplier == 1.5
+    assert furret.stab_multiplier == 2
+
     furret.start_effect("typechange", "???/Fighting")
     furret.start_effect("move: Skill Swap", ["Levitate", "Adaptability"])
+
     assert furret.types == [PokemonType.THREE_QUESTION_MARKS, PokemonType.FIGHTING]
     assert furret.ability == "levitate"
-    assert furret.damage_multiplier(PokemonType.PSYCHIC) == 2
+    assert furret.damage_multiplier(PokemonType.PSYCHIC) == 1
     assert furret.stab_multiplier == 1.5
+
+    furret.start_effect("typechange", "Fighting")
+    assert furret.damage_multiplier(PokemonType.PSYCHIC) == 2
+
+    furret.switch_out()
+    furret.switch_in()
+
+    assert furret.ability == "adaptability"
 
     furret.terastallize("dragon")
     assert furret.type_1 == PokemonType.DRAGON
-    assert furret.types == [PokemonType.DRAGON]
-    assert furret.stab_multiplier == 1.5
+    assert furret.type_2 is None
     assert furret.damage_multiplier(PokemonType.ICE) == 2
 
     furret.switch_out()
-    assert furret.types == [PokemonType.NORMAL]
-    assert furret.ability == "adaptability"
-    assert furret.stab_multiplier == 2
-
-    assert furret.damage_multiplier(PokemonType.NORMAL) == 1
+    assert furret.types == [PokemonType.DRAGON]

--- a/unit_tests/environment/test_pokemon.py
+++ b/unit_tests/environment/test_pokemon.py
@@ -307,3 +307,28 @@ def test_stats(example_request, showdown_format_teams):
         "spd": 120,
         "spe": 82,
     }
+
+
+def test_temporary():
+    furret = Pokemon(species="furret", gen=8)
+    assert furret.types == [PokemonType.NORMAL]
+    assert furret.stab_multiplier == 1.5
+    furret.start_effect("typechange", "???/Fighting")
+    furret.start_effect("move: Skill Swap", ["Levitate", "Adaptability"])
+    assert furret.types == [PokemonType.THREE_QUESTION_MARKS, PokemonType.FIGHTING]
+    assert furret.ability == "levitate"
+    assert furret.damage_multiplier(PokemonType.PSYCHIC) == 2
+    assert furret.stab_multiplier == 1.5
+
+    furret.terastallize("dragon")
+    assert furret.type_1 == PokemonType.DRAGON
+    assert furret.types == [PokemonType.DRAGON]
+    assert furret.stab_multiplier == 1.5
+    assert furret.damage_multiplier(PokemonType.ICE) == 2
+
+    furret.switch_out()
+    assert furret.types == [PokemonType.NORMAL]
+    assert furret.ability == "adaptability"
+    assert furret.stab_multiplier == 2
+
+    assert furret.damage_multiplier(PokemonType.NORMAL) == 1


### PR DESCRIPTION
Added support for Skill Swap and TypeChange; this allows for us to better track an `AbstractBattle` state that we weren't tracking before. Changes:
1. Added `_temporary_types` internal variable to `Pokemon` that overrides a mon's type (and type-related properties) until switched out. Also changed `_temporary_types` to a `List` because the gen7 exclusive move [Trick-or-Treat](https://bulbapedia.bulbagarden.net/wiki/Trick-or-Treat_(move)) adds typing to a mon's existing typing. Not supported now, but can be extended in the future.
3. Added `_temporary_ability` internal variable to `Pokemon` that overrides a mon's ability until switched out
4. Added parsing of `skillswap` to both update both mon's abilities, but to also update the mon's innate ability if previously unknown
5. Added support for parsing of ability-changing moves like [`worryseed`, `entrainment`, `doodle` and `roleplay`](https://bulbapedia.bulbagarden.net/wiki/Category:Ability-changing_moves) as defined in [showdown protocol](https://github.com/smogon/pokemon-showdown/blob/4cece4ee981d90b26c53ff28a0da9d0def84486b/data/moves.ts#L3956)
6. Added support for parsing of ability-changing moves like [`burnup`, `doubleshock`, ` and `roost`](https://bulbapedia.bulbagarden.net/wiki/Type#Typeless) as defined in [showdown protocol](https://github.com/smogon/pokemon-showdown/blob/4cece4ee981d90b26c53ff28a0da9d0def84486b/data/moves.ts#L2178)
7. Added associate tests both in `Pokemon` and also via `battle.parse_message()`


Mentioned here: https://github.com/hsahovic/poke-env/issues/629