### PR TITLE
More robust battle tracking

### DIFF
--- a/src/poke_env/player/baselines.py
+++ b/src/poke_env/player/baselines.py
@@ -1,5 +1,5 @@
 import random
-from typing import List
+from typing import List, Optional
 
 from poke_env.environment.abstract_battle import AbstractBattle
 from poke_env.environment.double_battle import DoubleBattle
@@ -29,7 +29,7 @@ class MaxBasePowerPlayer(Player):
         return self.choose_random_move(battle)
 
     def choose_doubles_move(self, battle: DoubleBattle):
-        orders: List[BattleOrder] = []
+        orders: List[Optional[BattleOrder]] = []
         switched_in = None
 
         if any(battle.force_switch):
@@ -51,7 +51,7 @@ class MaxBasePowerPlayer(Player):
             switches = [s for s in switches if s != switched_in]
 
             if not mon or mon.fainted:
-                orders.append(DefaultBattleOrder())
+                orders.append(None)
                 continue
             elif not moves and switches:
                 mon_to_switch_in = random.choice(switches)

--- a/src/poke_env/player/battle_order.py
+++ b/src/poke_env/player/battle_order.py
@@ -82,9 +82,9 @@ class DoubleBattleOrder(BattleOrder):
                 + self.second_order.message.replace("/choose ", "")
             )
         elif self.first_order:
-            return self.first_order.message + ", default"
+            return self.first_order.message + ", pass"
         elif self.second_order:
-            return self.second_order.message + ", default"
+            return "/choose pass, " + self.second_order.message.replace("/choose ", "")
         else:
             return self.DEFAULT_ORDER
 
@@ -104,10 +104,11 @@ class DoubleBattleOrder(BattleOrder):
             if orders:
                 return orders
         elif first_orders:
-            return [DoubleBattleOrder(first_order=order) for order in first_orders]
+            return [DoubleBattleOrder(order, None) for order in first_orders]
         elif second_orders:
-            return [DoubleBattleOrder(first_order=order) for order in second_orders]
-        return [DefaultBattleOrder()]
+            return [DoubleBattleOrder(None, order) for order in second_orders]
+        else:
+            return [DoubleBattleOrder(None, None)]
 
 
 class ForfeitBattleOrder(BattleOrder):

--- a/unit_tests/player/test_battle_orders.py
+++ b/unit_tests/player/test_battle_orders.py
@@ -35,10 +35,8 @@ def test_double_orders():
         DoubleBattleOrder(mon, move).message
         == "/choose switch lugia, move selfdestruct 2"
     )
-    assert DoubleBattleOrder(mon).message == "/choose switch lugia, default"
-    assert (
-        DoubleBattleOrder(None, move).message == "/choose move selfdestruct 2, default"
-    )
+    assert DoubleBattleOrder(mon).message == "/choose switch lugia, pass"
+    assert DoubleBattleOrder(None, move).message == "/choose pass, move selfdestruct 2"
     assert DoubleBattleOrder().message == "/choose default"
 
     orders = [move, mon]
@@ -53,12 +51,12 @@ def test_double_orders():
         "/choose switch lugia, move selfdestruct 2",
     }
     assert first == {
-        "/choose move selfdestruct 2, default",
-        "/choose switch lugia, default",
+        "/choose move selfdestruct 2, pass",
+        "/choose switch lugia, pass",
     }
     assert second == {
-        "/choose move selfdestruct 2, default",
-        "/choose switch lugia, default",
+        "/choose pass, move selfdestruct 2",
+        "/choose pass, switch lugia",
     }
     assert none == {"/choose default"}
 

--- a/unit_tests/player/test_doubles_baselines.py
+++ b/unit_tests/player/test_doubles_baselines.py
@@ -17,11 +17,11 @@ def test_doubles_max_damage_player():
     battle._active_pokemon["p1a"] = active_pikachu
 
     # calls player.choose_random_doubles_move(battle)
-    assert player.choose_move(battle).message == "/choose default, default"
+    assert player.choose_move(battle).message == "/choose default, pass"
 
     # calls player.choose_random_doubles_move(battle)
     battle._available_switches[0].append(Pokemon(species="ponyta", gen=8))
-    assert player.choose_move(battle).message == "/choose switch ponyta, default"
+    assert player.choose_move(battle).message == "/choose switch ponyta, pass"
 
     active_raichu = Pokemon(species="raichu", gen=8)
     active_raichu.switch_in()
@@ -65,12 +65,12 @@ def test_doubles_max_damage_player():
     # forced switch
     battle._force_switch = [True, False]
     assert player.choose_move(battle).message in [
-        "/choose switch ponyta, default",
+        "/choose switch ponyta, pass",
     ]
 
     battle._force_switch = [False, True]
     assert player.choose_move(battle).message in [
-        "/choose switch rapidash, default",
+        "/choose pass, switch rapidash",
     ]
 
     battle._force_switch = [True, True]


### PR DESCRIPTION
Fixes #616

1. Currently we consume the messages in the order they come in, which is request and then protocol message. We really should update the battle object with the protocol first, and then update with the battle request - and now we do! This is better because it prevents us from accidentally overwriting something that is definitely true with our interpretation of the protocol, which currently has bugs. Specifically, this guarantees that we can correctly track Zoroark if it's on our team, and it resolves several bugs in the parsing logic that were not causing errors up to this point.
1. There is no way to send pass in poke-env. Having DefaultBattleOrder as the default option for the orders in DoubleBattleOrder is misleading, and it really should be pass. The user could just provide DefaultBattleOrder to the DoubleBattleOrder constructor if they want one of the sides to be default, so this is a strict empowerment for the user.