### PR TITLE
Fix request/protocol order of consumption

### DIFF
--- a/src/poke_env/environment/abstract_battle.py
+++ b/src/poke_env/environment/abstract_battle.py
@@ -449,8 +449,8 @@ class AbstractBattle(ABC):
             if event[-1].startswith("[anim]"):
                 event = event[:-1]
 
-            if event[-1].startswith("[from]move: "):
-                override_move = event.pop()[12:]
+            if event[-1].startswith("[from] move: "):
+                override_move = event.pop()[13:]
 
                 if override_move == "Sleep Talk":
                     # Sleep talk was used, but also reveals another move
@@ -461,7 +461,7 @@ class AbstractBattle(ABC):
                     override_move = None
                 elif self.logger is not None:
                     self.logger.warning(
-                        "Unmanaged [from]move message received - move %s in cleaned up "
+                        "Unmanaged [from] move message received - move %s in cleaned up "
                         "message %s in battle %s turn %d",
                         override_move,
                         event,
@@ -472,8 +472,8 @@ class AbstractBattle(ABC):
             if event[-1] == "null":
                 event = event[:-1]
 
-            if event[-1].startswith("[from]ability: "):
-                revealed_ability = event.pop()[15:]
+            if event[-1].startswith("[from] ability: "):
+                revealed_ability = event.pop()[16:]
                 pokemon = event[2]
                 self.get_pokemon(pokemon).ability = revealed_ability
 
@@ -483,7 +483,7 @@ class AbstractBattle(ABC):
                     return
                 elif self.logger is not None:
                     self.logger.warning(
-                        "Unmanaged [from]ability: message received - ability %s in "
+                        "Unmanaged [from] ability: message received - ability %s in "
                         "cleaned up message %s in battle %s turn %d",
                         revealed_ability,
                         event,

--- a/src/poke_env/environment/battle.py
+++ b/src/poke_env/environment/battle.py
@@ -94,6 +94,16 @@ class Battle(AbstractBattle):
             self._teampreview = False
         self._update_team_from_request(request["side"])
 
+        if self.active_pokemon is not None:
+            active_mon = self.get_pokemon(
+                request["side"]["pokemon"][0]["ident"],
+                force_self_team=True,
+                details=request["side"]["pokemon"][0]["details"],
+            )
+            if active_mon != self.active_pokemon:
+                self.active_pokemon.switch_out()
+                active_mon.switch_in()
+
         if "active" in request:
             active_request = request["active"][0]
 

--- a/src/poke_env/environment/double_battle.py
+++ b/src/poke_env/environment/double_battle.py
@@ -130,6 +130,13 @@ class DoubleBattle(AbstractBattle):
         if side["pokemon"]:
             self._player_role = side["pokemon"][0]["ident"][:2]
         self._update_team_from_request(side)
+        if self.player_role is not None:
+            self._active_pokemon[f"{self.player_role}a"] = self.team[
+                request["side"]["pokemon"][0]["ident"]
+            ]
+            self._active_pokemon[f"{self.player_role}b"] = self.team[
+                request["side"]["pokemon"][1]["ident"]
+            ]
 
         if "active" in request:
             for active_pokemon_number, active_request in enumerate(request["active"]):
@@ -139,41 +146,6 @@ class DoubleBattle(AbstractBattle):
                     force_self_team=True,
                     details=pokemon_dict["details"],
                 )
-                if self.player_role is not None:
-                    if (
-                        active_pokemon_number == 0
-                        and f"{self.player_role}a" not in self._active_pokemon
-                    ):
-                        self._active_pokemon[f"{self.player_role}a"] = active_pokemon
-                    elif f"{self.player_role}b" not in self._active_pokemon:
-                        self._active_pokemon[f"{self.player_role}b"] = active_pokemon
-                    elif (
-                        active_pokemon_number == 0
-                        and self._active_pokemon[f"{self.player_role}a"].fainted
-                        and self._active_pokemon[f"{self.player_role}b"]
-                        == active_pokemon
-                    ):
-                        (
-                            self._active_pokemon[f"{self.player_role}a"],
-                            self._active_pokemon[f"{self.player_role}b"],
-                        ) = (
-                            self._active_pokemon[f"{self.player_role}b"],
-                            self._active_pokemon[f"{self.player_role}a"],
-                        )
-                    elif (
-                        active_pokemon_number == 1
-                        and self._active_pokemon[f"{self.player_role}b"].fainted
-                        and not active_pokemon.fainted
-                        and self._active_pokemon[f"{self.player_role}a"]
-                        == active_pokemon
-                    ):
-                        (
-                            self._active_pokemon[f"{self.player_role}a"],
-                            self._active_pokemon[f"{self.player_role}b"],
-                        ) = (
-                            self._active_pokemon[f"{self.player_role}b"],
-                            self._active_pokemon[f"{self.player_role}a"],
-                        )
 
                 if active_pokemon.fainted:
                     continue

--- a/src/poke_env/environment/pokemon.py
+++ b/src/poke_env/environment/pokemon.py
@@ -378,6 +378,7 @@ class Pokemon:
                 self.end_effect("yawn")
         else:
             hp = hp_status
+            self._status = None
 
         current_hp, max_hp = "".join([c for c in hp if c in "0123456789/"]).split("/")
         self._current_hp = int(current_hp)

--- a/unit_tests/environment/test_battle.py
+++ b/unit_tests/environment/test_battle.py
@@ -426,10 +426,16 @@ def test_battle_request_and_interactions(example_request):
     )
     assert "precipiceblades" in battle.opponent_active_pokemon.moves
 
-    event = ["", "move", "p1: Groudon", "Teeter Dance", "[from]ability: Dancer"]
+    event = ["", "move", "p1: Groudon", "Teeter Dance", "[from] ability: Dancer"]
     battle.parse_message(event)
     assert "teeterdance" not in battle.opponent_active_pokemon.moves
-    assert event == ["", "move", "p1: Groudon", "Teeter Dance", "[from]ability: Dancer"]
+    assert event == [
+        "",
+        "move",
+        "p1: Groudon",
+        "Teeter Dance",
+        "[from] ability: Dancer",
+    ]
 
     battle._player_username = "ray"
     battle._opponent_username = "wolfe"

--- a/unit_tests/environment/test_double_battle.py
+++ b/unit_tests/environment/test_double_battle.py
@@ -373,7 +373,7 @@ def test_pledge_moves():
             "p2a: Primarina",
             "Water Pledge",
             "p1b: Hatterene",
-            "[from]move: Grass Pledge",
+            "[from] move: Grass Pledge",
         ],
         ["", "-combine"],
         ["", "-damage", "p1b: Hatterene", "0 fnt"],


### PR DESCRIPTION
Fixes #616

Currently we consume the messages in the order they come in, which is request and then protocol message. We really should update the battle object with the protocol first, and then update with the battle request - and now we do! This is better because it prevents us from accidentally overwriting something that is definitely true with our interpretation of the protocol, which currently has bugs. Specifically, this guarantees that we can correctly track Zoroark if it's on our team, and it likely resolves many other bugs that have remained silent up to this point.

NOTE: This diff is minimal but somewhat hacky. I really would have loved to just rework the way the client-server interaction is going on so that the flow of the code could be a lot more natural, but I couldn't figure out how to do it without a gigantic diff. I leave it to a future brave soul to smooth this all out someday.