### PR TITLE
Revival Blessing Bugfix

### DIFF
--- a/src/poke_env/environment/pokemon.py
+++ b/src/poke_env/environment/pokemon.py
@@ -276,6 +276,8 @@ class Pokemon:
 
     def heal(self, hp_status: str):
         self.set_hp_status(hp_status)
+        if self.fainted:
+            self._status = None
 
     def invert_boosts(self):
         self._boosts = {k: -v for k, v in self._boosts.items()}


### PR DESCRIPTION
Fixes bug where revival blessing heals pokemon, but its faint status is not cleared. We fix this by making it so that any time `.heal()` is called on a fainted pokemon object, it always clears the `_status` field.