### PR TITLE
Get rid of last_battle

### DIFF
--- a/docs/source/examples/rl_with_gymnasium_wrapper.rst
+++ b/docs/source/examples/rl_with_gymnasium_wrapper.rst
@@ -58,9 +58,9 @@ Our player will play the ``gen8randombattle`` format. We can therefore inherit f
     from poke_env.player import Gen8EnvSinglePlayer
 
     class SimpleRLPlayer(Gen8EnvSinglePlayer):
-        def calc_reward(self, last_battle, current_battle) -> float:
+        def calc_reward(self, battle) -> float:
             return self.reward_computing_helper(
-                current_battle, fainted_value=2.0, hp_value=1.0, victory_value=30.0
+                battle, fainted_value=2.0, hp_value=1.0, victory_value=30.0
             )
 
         def embed_battle(self, battle: AbstractBattle) -> ObservationType:

--- a/examples/gymnasium_example.py
+++ b/examples/gymnasium_example.py
@@ -37,7 +37,7 @@ class TestEnv(GymnasiumEnv):
     def action_to_move(self, action, battle):
         return self.agent.choose_random_move(battle)
 
-    def calc_reward(self, last_battle, current_battle):
+    def calc_reward(self, battle):
         return 0.25
 
     def get_opponent(self):
@@ -45,8 +45,8 @@ class TestEnv(GymnasiumEnv):
 
 
 class Gen8(Gen8EnvSinglePlayer):
-    def calc_reward(self, last_battle, current_battle) -> float:
-        return self.reward_computing_helper(current_battle)
+    def calc_reward(self, battle) -> float:
+        return self.reward_computing_helper(battle)
 
     def embed_battle(self, battle: AbstractBattle) -> ObservationType:
         to_embed = []

--- a/examples/rl_with_gymnasium_wrapper.py
+++ b/examples/rl_with_gymnasium_wrapper.py
@@ -24,9 +24,9 @@ from poke_env.player import (
 
 
 class SimpleRLPlayer(Gen8EnvSinglePlayer):
-    def calc_reward(self, last_battle, current_battle) -> float:
+    def calc_reward(self, battle) -> float:
         return self.reward_computing_helper(
-            current_battle, fainted_value=2.0, hp_value=1.0, victory_value=30.0
+            battle, fainted_value=2.0, hp_value=1.0, victory_value=30.0
         )
 
     def embed_battle(self, battle: AbstractBattle) -> ObservationType:

--- a/integration_tests/test_env_player.py
+++ b/integration_tests/test_env_player.py
@@ -14,7 +14,7 @@ from poke_env.player import (
 
 
 class RandomGen4EnvPlayer(Gen4EnvSinglePlayer):
-    def calc_reward(self, last_battle, current_battle) -> float:
+    def calc_reward(self, battle) -> float:
         return 0.0
 
     def describe_embedding(self) -> Space:
@@ -25,7 +25,7 @@ class RandomGen4EnvPlayer(Gen4EnvSinglePlayer):
 
 
 class RandomGen5EnvPlayer(Gen5EnvSinglePlayer):
-    def calc_reward(self, last_battle, current_battle) -> float:
+    def calc_reward(self, battle) -> float:
         return 0.0
 
     def describe_embedding(self) -> Space:
@@ -36,7 +36,7 @@ class RandomGen5EnvPlayer(Gen5EnvSinglePlayer):
 
 
 class RandomGen6EnvPlayer(Gen6EnvSinglePlayer):
-    def calc_reward(self, last_battle, current_battle) -> float:
+    def calc_reward(self, battle) -> float:
         return 0.0
 
     def describe_embedding(self) -> Space:
@@ -47,7 +47,7 @@ class RandomGen6EnvPlayer(Gen6EnvSinglePlayer):
 
 
 class RandomGen7EnvPlayer(Gen7EnvSinglePlayer):
-    def calc_reward(self, last_battle, current_battle) -> float:
+    def calc_reward(self, battle) -> float:
         return 0.0
 
     def describe_embedding(self) -> Space:
@@ -58,7 +58,7 @@ class RandomGen7EnvPlayer(Gen7EnvSinglePlayer):
 
 
 class RandomGen8EnvPlayer(Gen8EnvSinglePlayer):
-    def calc_reward(self, last_battle, current_battle) -> float:
+    def calc_reward(self, battle) -> float:
         return 0.0
 
     def describe_embedding(self) -> Space:
@@ -69,7 +69,7 @@ class RandomGen8EnvPlayer(Gen8EnvSinglePlayer):
 
 
 class RandomGen9EnvPlayer(Gen9EnvSinglePlayer):
-    def calc_reward(self, last_battle, current_battle) -> float:
+    def calc_reward(self, battle) -> float:
         return 0.0
 
     def describe_embedding(self) -> Space:

--- a/src/poke_env/player/gymnasium_api.py
+++ b/src/poke_env/player/gymnasium_api.py
@@ -371,11 +371,8 @@ class GymnasiumEnv(ParallelEnv[str, ObsType, ActionType]):
     @abstractmethod
     def calc_reward(self, battle: AbstractBattle) -> float:
         """
-        Returns the reward for the current battle state. The battle state in the previous
-        turn is given as well and can be used for comparisons.
+        Returns the reward for the current battle state.
 
-        :param last_battle: The battle state in the previous turn.
-        :type last_battle: AbstractBattle
         :param battle: The current battle state.
         :type battle: AbstractBattle
 

--- a/src/poke_env/player/gymnasium_api.py
+++ b/src/poke_env/player/gymnasium_api.py
@@ -78,7 +78,7 @@ class _AsyncPlayer(Player):
         self.__class__.__name__ = "_AsyncPlayer"
         self.observations = _AsyncQueue(create_in_poke_loop(asyncio.Queue, 1))
         self.actions = _AsyncQueue(create_in_poke_loop(asyncio.Queue, 1))
-        self.current_battle: Optional[AbstractBattle] = None
+        self.battle: Optional[AbstractBattle] = None
         self.waiting = False
         self._user_funcs = user_funcs
 
@@ -86,9 +86,9 @@ class _AsyncPlayer(Player):
         return self._env_move(battle)
 
     async def _env_move(self, battle: AbstractBattle) -> BattleOrder:
-        if not self.current_battle or self.current_battle.finished:
-            self.current_battle = battle
-        if not self.current_battle == battle:
+        if not self.battle or self.battle.finished:
+            self.battle = battle
+        if not self.battle == battle:
             raise RuntimeError("Using different battles for queues")
         battle_to_send = self._user_funcs.embed_battle(battle)
         await self.observations.async_put(battle_to_send)
@@ -231,10 +231,8 @@ class GymnasiumEnv(ParallelEnv[str, ObsType, ActionType]):
         self._observations1 = self.agent1.observations
         self._actions2 = self.agent2.actions
         self._observations2 = self.agent2.observations
-        self.current_battle1: Optional[AbstractBattle] = None
-        self.current_battle2: Optional[AbstractBattle] = None
-        self.last_battle1: Optional[AbstractBattle] = None
-        self.last_battle2: Optional[AbstractBattle] = None
+        self.battle1: Optional[AbstractBattle] = None
+        self.battle2: Optional[AbstractBattle] = None
         self._keep_challenging: bool = False
         self._challenge_task = None
         self._seed_initialized: bool = False
@@ -255,38 +253,32 @@ class GymnasiumEnv(ParallelEnv[str, ObsType, ActionType]):
         Dict[str, bool],
         Dict[str, Dict[str, Any]],
     ]:
-        assert self.current_battle1 is not None
-        assert self.current_battle2 is not None
-        if self.current_battle1.finished:
+        assert self.battle1 is not None
+        assert self.battle2 is not None
+        if self.battle1.finished:
             raise RuntimeError("Battle is already finished, call reset")
-        battle1 = copy.copy(self.current_battle1)
-        battle1.logger = None
-        battle2 = copy.copy(self.current_battle2)
-        battle2.logger = None
-        self.last_battle1 = battle1
-        self.last_battle2 = battle2
         if self.agent1.waiting:
             self._actions1.put(actions[self.agents[0]])
         if self.agent2.waiting:
             self._actions2.put(actions[self.agents[1]])
         observations = {
             self.agents[0]: self._observations1.get(
-                timeout=0.1, default=self.embed_battle(self.last_battle1)
+                timeout=0.1, default=self.embed_battle(self.battle1)
             ),
             self.agents[1]: self._observations2.get(
-                timeout=0.1, default=self.embed_battle(self.last_battle2)
+                timeout=0.1, default=self.embed_battle(self.battle2)
             ),
         }
-        assert self.current_battle1 == self.agent1.current_battle
+        assert self.battle1 == self.agent1.battle
         reward = {
-            self.agents[0]: self.calc_reward(self.last_battle1, self.current_battle1),
-            self.agents[1]: self.calc_reward(self.last_battle2, self.current_battle2),
+            self.agents[0]: self.calc_reward(self.battle1),
+            self.agents[1]: self.calc_reward(self.battle2),
         }
-        term1, trunc1 = self.calc_term_trunc(self.current_battle1)
-        term2, trunc2 = self.calc_term_trunc(self.current_battle2)
+        term1, trunc1 = self.calc_term_trunc(self.battle1)
+        term2, trunc2 = self.calc_term_trunc(self.battle2)
         terminated = {self.agents[0]: term1, self.agents[1]: term2}
         truncated = {self.agents[0]: trunc1, self.agents[1]: trunc2}
-        if self.current_battle1.finished:
+        if self.battle1.finished:
             self.agents = []
         return observations, reward, terminated, truncated, self.get_additional_info()
 
@@ -297,15 +289,15 @@ class GymnasiumEnv(ParallelEnv[str, ObsType, ActionType]):
     ) -> Tuple[Dict[str, ObsType], Dict[str, Dict[str, Any]]]:
         self.agents = [self.agent1.username, self.agent2.username]
         # TODO: use the seed
-        if not self.agent1.current_battle or not self.agent2.current_battle:
+        if not self.agent1.battle or not self.agent2.battle:
             count = self._INIT_RETRIES
-            while not self.agent1.current_battle or not self.agent2.current_battle:
+            while not self.agent1.battle or not self.agent2.battle:
                 if count == 0:
                     raise RuntimeError("Agent is not challenging")
                 count -= 1
                 time.sleep(self._TIME_BETWEEN_RETRIES)
-        if self.current_battle1 and not self.current_battle1.finished:
-            if self.current_battle1 == self.agent1.current_battle:
+        if self.battle1 and not self.battle1.finished:
+            if self.battle1 == self.agent1.battle:
                 self._actions1.put(-1)
                 self._actions2.put(0)
                 self._observations1.get()
@@ -314,56 +306,54 @@ class GymnasiumEnv(ParallelEnv[str, ObsType, ActionType]):
                 raise RuntimeError(
                     "Environment and agent aren't synchronized. Try to restart"
                 )
-        while self.current_battle1 == self.agent1.current_battle:
+        while self.battle1 == self.agent1.battle:
             time.sleep(0.01)
         observations = {
             self.agents[0]: self._observations1.get(),
             self.agents[1]: self._observations2.get(),
         }
-        self.current_battle1 = self.agent1.current_battle
-        self.current_battle1.logger = None
-        self.current_battle2 = self.agent2.current_battle
-        self.current_battle2.logger = None
-        self.last_battle1 = self.current_battle1
-        self.last_battle2 = self.current_battle2
+        self.battle1 = self.agent1.battle
+        self.battle1.logger = None
+        self.battle2 = self.agent2.battle
+        self.battle2.logger = None
         return observations, self.get_additional_info()
 
     def render(self, mode: str = "human"):
-        if self.current_battle1 is not None:
+        if self.battle1 is not None:
             print(
                 "  Turn %4d. | [%s][%3d/%3dhp] %10.10s - %10.10s [%3d%%hp][%s]"
                 % (
-                    self.current_battle1.turn,
+                    self.battle1.turn,
                     "".join(
                         [
                             "⦻" if mon.fainted else "●"
-                            for mon in self.current_battle1.team.values()
+                            for mon in self.battle1.team.values()
                         ]
                     ),
-                    self.current_battle1.active_pokemon.current_hp or 0,
-                    self.current_battle1.active_pokemon.max_hp or 0,
-                    self.current_battle1.active_pokemon.species,
-                    self.current_battle1.opponent_active_pokemon.species,
-                    self.current_battle1.opponent_active_pokemon.current_hp or 0,
+                    self.battle1.active_pokemon.current_hp or 0,
+                    self.battle1.active_pokemon.max_hp or 0,
+                    self.battle1.active_pokemon.species,
+                    self.battle1.opponent_active_pokemon.species,
+                    self.battle1.opponent_active_pokemon.current_hp or 0,
                     "".join(
                         [
                             "⦻" if mon.fainted else "●"
-                            for mon in self.current_battle1.opponent_team.values()
+                            for mon in self.battle1.opponent_team.values()
                         ]
                     ),
                 ),
-                end="\n" if self.current_battle1.finished else "\r",
+                end="\n" if self.battle1.finished else "\r",
             )
 
     def close(self, purge: bool = True):
-        if self.current_battle1 is None or self.current_battle1.finished:
+        if self.battle1 is None or self.battle1.finished:
             time.sleep(1)
-            if self.current_battle1 != self.agent1.current_battle:
-                self.current_battle1 = self.agent1.current_battle
-        if self.current_battle2 is None or self.current_battle2.finished:
+            if self.battle1 != self.agent1.battle:
+                self.battle1 = self.agent1.battle
+        if self.battle2 is None or self.battle2.finished:
             time.sleep(1)
-            if self.current_battle2 != self.agent2.current_battle:
-                self.current_battle2 = self.agent2.current_battle
+            if self.battle2 != self.agent2.battle:
+                self.battle2 = self.agent2.battle
         closing_task = asyncio.run_coroutine_threadsafe(
             self._stop_challenge_loop(purge=purge), POKE_LOOP
         )
@@ -379,19 +369,17 @@ class GymnasiumEnv(ParallelEnv[str, ObsType, ActionType]):
     # Abstract methods
 
     @abstractmethod
-    def calc_reward(
-        self, last_battle: AbstractBattle, current_battle: AbstractBattle
-    ) -> float:
+    def calc_reward(self, battle: AbstractBattle) -> float:
         """
         Returns the reward for the current battle state. The battle state in the previous
         turn is given as well and can be used for comparisons.
 
         :param last_battle: The battle state in the previous turn.
         :type last_battle: AbstractBattle
-        :param current_battle: The current battle state.
-        :type current_battle: AbstractBattle
+        :param battle: The current battle state.
+        :type battle: AbstractBattle
 
-        :return: The reward for current_battle.
+        :return: The reward for battle.
         :rtype: float
         """
         pass
@@ -521,13 +509,13 @@ class GymnasiumEnv(ParallelEnv[str, ObsType, ActionType]):
         if not n_challenges:
             while self._keep_challenging:
                 await self.agent1.battle_against(self.agent2, n_battles=1)
-                if callback and self.current_battle1 is not None:
-                    callback(copy.deepcopy(self.current_battle1))
+                if callback and self.battle1 is not None:
+                    callback(copy.deepcopy(self.battle1))
         elif n_challenges > 0:
             for _ in range(n_challenges):
                 await self.agent1.battle_against(self.agent2, n_battles=1)
-                if callback and self.current_battle1 is not None:
-                    callback(copy.deepcopy(self.current_battle1))
+                if callback and self.battle1 is not None:
+                    callback(copy.deepcopy(self.battle1))
         else:
             raise ValueError(f"Number of challenges must be > 0. Got {n_challenges}")
 
@@ -571,13 +559,13 @@ class GymnasiumEnv(ParallelEnv[str, ObsType, ActionType]):
                 )
             for _ in range(n_challenges):
                 await self.agent1.ladder(1)
-                if callback and self.current_battle1 is not None:
-                    callback(self.current_battle1)
+                if callback and self.battle1 is not None:
+                    callback(self.battle1)
         else:
             while self._keep_challenging:
                 await self.agent1.ladder(1)
-                if callback and self.current_battle1 is not None:
-                    callback(self.current_battle1)
+                if callback and self.battle1 is not None:
+                    callback(self.battle1)
 
     def start_laddering(
         self,
@@ -613,7 +601,7 @@ class GymnasiumEnv(ParallelEnv[str, ObsType, ActionType]):
         self._keep_challenging = False
 
         if force:
-            if self.current_battle1 and not self.current_battle1.finished:
+            if self.battle1 and not self.battle1.finished:
                 if not (self._actions1.empty() and self._actions2.empty()):
                     await asyncio.sleep(2)
                     if not (self._actions1.empty() and self._actions2.empty()):
@@ -635,10 +623,10 @@ class GymnasiumEnv(ParallelEnv[str, ObsType, ActionType]):
             self._challenge_task.result()
 
         self._challenge_task = None
-        self.current_battle1 = None
-        self.current_battle2 = None
-        self.agent1.current_battle = None
-        self.agent2.current_battle = None
+        self.battle1 = None
+        self.battle2 = None
+        self.agent1.battle = None
+        self.agent2.battle = None
         while not self._actions1.empty():
             await self._actions1.async_get()
         while not self._actions2.empty():

--- a/unit_tests/player/test_env_player.py
+++ b/unit_tests/player/test_env_player.py
@@ -25,7 +25,7 @@ server_configuration = ServerConfiguration("server.url", "auth.url")
 
 
 class CustomEnvPlayer(EnvPlayer):
-    def calc_reward(self, last_battle, current_battle) -> float:
+    def calc_reward(self, battle) -> float:
         pass
 
     def action_to_move(self, action: int, battle: AbstractBattle) -> BattleOrder:
@@ -247,7 +247,7 @@ def test_action_space():
             def embed_battle(self, *args, **kwargs):
                 return []
 
-            def calc_reward(self, last_battle, current_battle):
+            def calc_reward(self, battle):
                 return 0.0
 
             def describe_embedding(self):
@@ -288,7 +288,7 @@ def test_action_to_move(z_moves_mock):
             def embed_battle(self, *args, **kwargs):
                 return []
 
-            def calc_reward(self, last_battle, current_battle):
+            def calc_reward(self, battle):
                 return 0.0
 
             def describe_embedding(self):

--- a/unit_tests/player/test_gymnasium.py
+++ b/unit_tests/player/test_gymnasium.py
@@ -15,9 +15,7 @@ class DummyEnv(GymnasiumEnv[ObsType, ActionType]):
         self.opponent = None
         super().__init__(*args, **kwargs)
 
-    def calc_reward(
-        self, last_battle: AbstractBattle, current_battle: AbstractBattle
-    ) -> float:
+    def calc_reward(self, battle: AbstractBattle) -> float:
         return 69.42
 
     def action_to_move(self, action: int, battle: AbstractBattle) -> BattleOrder:

--- a/unit_tests/player/test_gymnasium.py
+++ b/unit_tests/player/test_gymnasium.py
@@ -73,7 +73,7 @@ def render(battle):
     player = DummyEnv(start_listening=False)
     captured_output = StringIO()
     sys.stdout = captured_output
-    player.current_battle1 = battle
+    player.battle1 = battle
     player.render()
     sys.stdout = sys.__stdout__
     return captured_output.getvalue()


### PR DESCRIPTION
This should help some with the diff of #668.

I removed `last_battle` as a tracked entity in the env. This is because if the user of poke-env wants to track the last battle object, they can copy it for themselves, but we shouldn't be doing it if the user doesn't want that. This allowed me to rename `current_battle` -> `battle` all over the code in gymnasium_api.py.