### PR TITLE
Don't pass env into `_EnvPlayer` instantiation

### DIFF
--- a/examples/gymnasium_example.py
+++ b/examples/gymnasium_example.py
@@ -34,7 +34,7 @@ class TestEnv(GymnasiumEnv):
             dtype=np.float64,
         )
 
-    def action_to_move(self, action, battle):
+    def action_to_order(self, action, battle):
         return self.agent.choose_random_move(battle)
 
     def calc_reward(self, last_battle, current_battle):

--- a/src/poke_env/player/env_player.py
+++ b/src/poke_env/player/env_player.py
@@ -226,7 +226,7 @@ class Gen4EnvSinglePlayer(EnvPlayer):
     _ACTION_SPACE = list(range(4 + 6))
     _DEFAULT_BATTLE_FORMAT = "gen4randombattle"
 
-    def action_to_move(self, action: np.int64, battle: AbstractBattle) -> BattleOrder:
+    def action_to_order(self, action: np.int64, battle: AbstractBattle) -> BattleOrder:
         """Converts actions to move orders.
 
         The conversion is done as follows:
@@ -269,7 +269,7 @@ class Gen6EnvSinglePlayer(EnvPlayer):
     _ACTION_SPACE = list(range(2 * 4 + 6))
     _DEFAULT_BATTLE_FORMAT = "gen6randombattle"
 
-    def action_to_move(self, action: np.int64, battle: AbstractBattle) -> BattleOrder:
+    def action_to_order(self, action: np.int64, battle: AbstractBattle) -> BattleOrder:
         """Converts actions to move orders.
 
         The conversion is done as follows:
@@ -317,7 +317,7 @@ class Gen7EnvSinglePlayer(EnvPlayer):
     _ACTION_SPACE = list(range(3 * 4 + 6))
     _DEFAULT_BATTLE_FORMAT = "gen7randombattle"
 
-    def action_to_move(self, action: np.int64, battle: AbstractBattle) -> BattleOrder:
+    def action_to_order(self, action: np.int64, battle: AbstractBattle) -> BattleOrder:
         """Converts actions to move orders.
 
         The conversion is done as follows:
@@ -377,7 +377,7 @@ class Gen8EnvSinglePlayer(EnvPlayer):
     _ACTION_SPACE = list(range(4 * 4 + 6))
     _DEFAULT_BATTLE_FORMAT = "gen8randombattle"
 
-    def action_to_move(self, action: np.int64, battle: AbstractBattle) -> BattleOrder:
+    def action_to_order(self, action: np.int64, battle: AbstractBattle) -> BattleOrder:
         """Converts actions to move orders.
 
         The conversion is done as follows:
@@ -451,7 +451,7 @@ class Gen9EnvSinglePlayer(EnvPlayer):
     _ACTION_SPACE = list(range(5 * 4 + 6))
     _DEFAULT_BATTLE_FORMAT = "gen9randombattle"
 
-    def action_to_move(self, action: np.int64, battle: AbstractBattle) -> BattleOrder:
+    def action_to_order(self, action: np.int64, battle: AbstractBattle) -> BattleOrder:
         """Converts actions to move orders.
 
         The conversion is done as follows:

--- a/src/poke_env/player/env_player.py
+++ b/src/poke_env/player/env_player.py
@@ -4,6 +4,8 @@
 from typing import List, Optional, Union
 from weakref import WeakKeyDictionary
 
+import numpy as np
+
 from poke_env.environment.abstract_battle import AbstractBattle
 from poke_env.player.battle_order import BattleOrder, ForfeitBattleOrder
 from poke_env.player.gymnasium_api import GymnasiumEnv
@@ -224,7 +226,7 @@ class Gen4EnvSinglePlayer(EnvPlayer):
     _ACTION_SPACE = list(range(4 + 6))
     _DEFAULT_BATTLE_FORMAT = "gen4randombattle"
 
-    def action_to_move(self, action: int, battle: AbstractBattle) -> BattleOrder:
+    def action_to_move(self, action: np.int64, battle: AbstractBattle) -> BattleOrder:
         """Converts actions to move orders.
 
         The conversion is done as follows:
@@ -239,7 +241,7 @@ class Gen4EnvSinglePlayer(EnvPlayer):
         If the proposed action is illegal, a random legal move is performed.
 
         :param action: The action to convert.
-        :type action: int
+        :type action: np.int64
         :param battle: The battle in which to act.
         :type battle: Battle
         :return: the order to send to the server.
@@ -267,7 +269,7 @@ class Gen6EnvSinglePlayer(EnvPlayer):
     _ACTION_SPACE = list(range(2 * 4 + 6))
     _DEFAULT_BATTLE_FORMAT = "gen6randombattle"
 
-    def action_to_move(self, action: int, battle: AbstractBattle) -> BattleOrder:
+    def action_to_move(self, action: np.int64, battle: AbstractBattle) -> BattleOrder:
         """Converts actions to move orders.
 
         The conversion is done as follows:
@@ -285,7 +287,7 @@ class Gen6EnvSinglePlayer(EnvPlayer):
         If the proposed action is illegal, a random legal move is performed.
 
         :param action: The action to convert.
-        :type action: int
+        :type action: np.int64
         :param battle: The battle in which to act.
         :type battle: Battle
         :return: the order to send to the server.
@@ -315,7 +317,7 @@ class Gen7EnvSinglePlayer(EnvPlayer):
     _ACTION_SPACE = list(range(3 * 4 + 6))
     _DEFAULT_BATTLE_FORMAT = "gen7randombattle"
 
-    def action_to_move(self, action: int, battle: AbstractBattle) -> BattleOrder:
+    def action_to_move(self, action: np.int64, battle: AbstractBattle) -> BattleOrder:
         """Converts actions to move orders.
 
         The conversion is done as follows:
@@ -336,7 +338,7 @@ class Gen7EnvSinglePlayer(EnvPlayer):
         If the proposed action is illegal, a random legal move is performed.
 
         :param action: The action to convert.
-        :type action: int
+        :type action: np.int64
         :param battle: The battle in which to act.
         :type battle: Battle
         :return: the order to send to the server.
@@ -375,7 +377,7 @@ class Gen8EnvSinglePlayer(EnvPlayer):
     _ACTION_SPACE = list(range(4 * 4 + 6))
     _DEFAULT_BATTLE_FORMAT = "gen8randombattle"
 
-    def action_to_move(self, action: int, battle: AbstractBattle) -> BattleOrder:
+    def action_to_move(self, action: np.int64, battle: AbstractBattle) -> BattleOrder:
         """Converts actions to move orders.
 
         The conversion is done as follows:
@@ -402,7 +404,7 @@ class Gen8EnvSinglePlayer(EnvPlayer):
         If the proposed action is illegal, a random legal move is performed.
 
         :param action: The action to convert.
-        :type action: int
+        :type action: np.int64
         :param battle: The battle in which to act.
         :type battle: Battle
         :return: the order to send to the server.
@@ -449,7 +451,7 @@ class Gen9EnvSinglePlayer(EnvPlayer):
     _ACTION_SPACE = list(range(5 * 4 + 6))
     _DEFAULT_BATTLE_FORMAT = "gen9randombattle"
 
-    def action_to_move(self, action: int, battle: AbstractBattle) -> BattleOrder:
+    def action_to_move(self, action: np.int64, battle: AbstractBattle) -> BattleOrder:
         """Converts actions to move orders.
 
         The conversion is done as follows:
@@ -479,7 +481,7 @@ class Gen9EnvSinglePlayer(EnvPlayer):
         If the proposed action is illegal, a random legal move is performed.
 
         :param action: The action to convert.
-        :type action: int
+        :type action: np.int64
         :param battle: The battle in which to act.
         :type battle: Battle
         :return: the order to send to the server.

--- a/src/poke_env/player/gymnasium_api.py
+++ b/src/poke_env/player/gymnasium_api.py
@@ -81,8 +81,8 @@ class _AsyncQueue(Generic[ItemType]):
 
 
 class _EnvPlayer(Player):
-    order_queue: _AsyncQueue[BattleOrder]
     battle_queue: _AsyncQueue[AbstractBattle]
+    order_queue: _AsyncQueue[BattleOrder]
 
     def __init__(
         self,

--- a/src/poke_env/player/gymnasium_api.py
+++ b/src/poke_env/player/gymnasium_api.py
@@ -21,12 +21,9 @@ from typing import (
     Union,
 )
 
+import numpy as np
 from gymnasium.spaces import Discrete, Space
-from pettingzoo.utils.env import (  # type: ignore[import-untyped]
-    ActionType,
-    ObsType,
-    ParallelEnv,
-)
+from pettingzoo.utils.env import ObsType, ParallelEnv  # type: ignore[import-untyped]
 
 from poke_env.concurrency import POKE_LOOP, create_in_poke_loop
 from poke_env.environment.abstract_battle import AbstractBattle
@@ -118,7 +115,7 @@ class _EnvPlayer(Player):
         asyncio.run_coroutine_threadsafe(self.battle_queue.async_put(battle), POKE_LOOP)
 
 
-class GymnasiumEnv(ParallelEnv[str, ObsType, ActionType]):
+class GymnasiumEnv(ParallelEnv[str, ObsType, np.int64]):
     """
     Base class implementing the Gymnasium API on the main thread.
     """
@@ -256,7 +253,7 @@ class GymnasiumEnv(ParallelEnv[str, ObsType, ActionType]):
     # PettingZoo API
     # https://pettingzoo.farama.org/api/parallel/#parallelenv
 
-    def step(self, actions: Dict[str, ActionType]) -> Tuple[
+    def step(self, actions: Dict[str, np.int64]) -> Tuple[
         Dict[str, ObsType],
         Dict[str, float],
         Dict[str, bool],
@@ -409,7 +406,7 @@ class GymnasiumEnv(ParallelEnv[str, ObsType, ActionType]):
         pass
 
     @abstractmethod
-    def action_to_move(self, action: ActionType, battle: AbstractBattle) -> BattleOrder:
+    def action_to_move(self, action: np.int64, battle: AbstractBattle) -> BattleOrder:
         """
         Returns the BattleOrder relative to the given action.
 

--- a/src/poke_env/player/gymnasium_api.py
+++ b/src/poke_env/player/gymnasium_api.py
@@ -269,10 +269,10 @@ class GymnasiumEnv(ParallelEnv[str, ObsType, np.int64]):
         self.last_battle2 = copy.copy(self.current_battle2)
         self.last_battle2.logger = None
         if self.agent1.waiting:
-            order1 = self.action_to_move(actions[self.agents[0]], self.current_battle1)
+            order1 = self.action_to_order(actions[self.agents[0]], self.current_battle1)
             self.agent1.order_queue.put(order1)
         if self.agent2.waiting:
-            order2 = self.action_to_move(actions[self.agents[1]], self.current_battle2)
+            order2 = self.action_to_order(actions[self.agents[1]], self.current_battle2)
             self.agent2.order_queue.put(order2)
         battle1 = self.agent1.battle_queue.get(
             timeout=0.01, default=self.current_battle1
@@ -406,7 +406,7 @@ class GymnasiumEnv(ParallelEnv[str, ObsType, np.int64]):
         pass
 
     @abstractmethod
-    def action_to_move(self, action: np.int64, battle: AbstractBattle) -> BattleOrder:
+    def action_to_order(self, action: np.int64, battle: AbstractBattle) -> BattleOrder:
         """
         Returns the BattleOrder relative to the given action.
 

--- a/unit_tests/player/test_env_player.py
+++ b/unit_tests/player/test_env_player.py
@@ -63,24 +63,19 @@ async def run_test_choose_move():
         battle_format="gen7randombattles",
         start_challenging=False,
     )
-
     # Create a mock battle and moves
     battle = Battle("bat1", player.agent1.username, player.agent1.logger, gen=8)
     battle._available_moves = [Move("flamethrower", gen=8)]
-
     # Test choosing a move
     message = await player.agent1.choose_move(battle)
     order = player.action_to_move(np.int64(6), battle)
     player.agent1.order_queue.put(order)
-
     assert message.message == "/choose move flamethrower"
-
     # Test switching Pokémon
     battle._available_switches = [Pokemon(species="charizard", gen=8)]
     message = await player.agent1.choose_move(battle)
     order = player.action_to_move(np.int64(0), battle)
     player.agent1.order_queue.put(order)
-
     assert message.message == "/choose switch charizard"
 
 

--- a/unit_tests/player/test_env_player.py
+++ b/unit_tests/player/test_env_player.py
@@ -25,7 +25,7 @@ account_configuration2 = AccountConfiguration("username2", "password2")
 server_configuration = ServerConfiguration("server.url", "auth.url")
 
 
-class CustomEnv(EnvPlayer):
+class CustomEnvPlayer(EnvPlayer):
     def calc_reward(self, last_battle, current_battle) -> float:
         pass
 
@@ -42,7 +42,7 @@ class CustomEnv(EnvPlayer):
 
 
 def test_init():
-    gymnasium_env = CustomEnv(
+    gymnasium_env = CustomEnvPlayer(
         account_configuration1=account_configuration1,
         account_configuration2=account_configuration2,
         server_configuration=server_configuration,
@@ -50,12 +50,12 @@ def test_init():
         battle_format="gen7randombattles",
     )
     player = gymnasium_env.agent1
-    assert isinstance(gymnasium_env, CustomEnv)
+    assert isinstance(gymnasium_env, CustomEnvPlayer)
     assert isinstance(player, _EnvPlayer)
 
 
 async def run_test_choose_move():
-    player = CustomEnv(
+    player = CustomEnvPlayer(
         account_configuration1=account_configuration1,
         account_configuration2=account_configuration2,
         server_configuration=server_configuration,
@@ -89,7 +89,7 @@ def test_choose_move():
 
 
 def test_reward_computing_helper():
-    player = CustomEnv(
+    player = CustomEnvPlayer(
         account_configuration1=account_configuration1,
         account_configuration2=account_configuration2,
         server_configuration=server_configuration,
@@ -212,7 +212,7 @@ def test_reward_computing_helper():
 
 
 def test_action_space():
-    player = CustomEnv(start_listening=False)
+    player = CustomEnvPlayer(start_listening=False)
     assert player.action_space(player.possible_agents[0]) == Discrete(
         len(Gen7EnvSinglePlayer._ACTION_SPACE)
     )
@@ -234,7 +234,7 @@ def test_action_space():
         ],
     ):
 
-        class CustomEnvClass(PlayerClass):
+        class CustomEnvPlayerClass(PlayerClass):
             def embed_battle(self, *args, **kwargs):
                 return []
 
@@ -244,7 +244,7 @@ def test_action_space():
             def describe_embedding(self):
                 return None
 
-        p = CustomEnvClass(start_listening=False, start_challenging=False)
+        p = CustomEnvPlayerClass(start_listening=False, start_challenging=False)
 
         assert p.action_space(p.possible_agents[0]) == Discrete(
             4 * sum([1, has_megas, has_z_moves, has_dynamax]) + 6
@@ -275,7 +275,7 @@ def test_action_to_move(z_moves_mock):
         ],
     ):
 
-        class CustomEnvClass(PlayerClass):
+        class CustomEnvPlayerClass(PlayerClass):
             def embed_battle(self, *args, **kwargs):
                 return []
 
@@ -288,7 +288,7 @@ def test_action_to_move(z_moves_mock):
             def get_opponent(self):
                 return None
 
-        p = CustomEnvClass(start_listening=False, start_challenging=False)
+        p = CustomEnvPlayerClass(start_listening=False, start_challenging=False)
         battle = Battle("bat1", p.agent1.username, p.agent1.logger, gen=8)
         assert p.action_to_move(-1, battle).message == "/forfeit"
         battle._available_moves = [Move("flamethrower", gen=8)]

--- a/unit_tests/player/test_env_player.py
+++ b/unit_tests/player/test_env_player.py
@@ -85,7 +85,7 @@ async def run_test_choose_move():
     assert message.message == "/choose switch charizard"
 
 
-def test_choose_move(queue_put_mock, queue_get_mock):
+def test_choose_move():
     asyncio.run_coroutine_threadsafe(run_test_choose_move(), POKE_LOOP)
 
 

--- a/unit_tests/player/test_env_player.py
+++ b/unit_tests/player/test_env_player.py
@@ -1,6 +1,5 @@
 import asyncio
 import unittest
-from inspect import isawaitable
 from unittest.mock import patch
 
 import numpy as np

--- a/unit_tests/player/test_env_player.py
+++ b/unit_tests/player/test_env_player.py
@@ -315,7 +315,8 @@ def test_action_to_order(z_moves_mock):
             battle._team = {"charizard": active_pokemon}
             z_moves_mock.return_value = [Move("flamethrower", gen=8)]
             assert (
-                p.action_to_order(4, battle).message == "/choose move flamethrower zmove"
+                p.action_to_order(4, battle).message
+                == "/choose move flamethrower zmove"
             )
             battle._team = {}
         if has_dynamax:

--- a/unit_tests/player/test_env_player.py
+++ b/unit_tests/player/test_env_player.py
@@ -29,8 +29,8 @@ class CustomEnvPlayer(EnvPlayer):
     def calc_reward(self, last_battle, current_battle) -> float:
         pass
 
-    def action_to_move(self, action: np.int64, battle: AbstractBattle) -> BattleOrder:
-        return Gen7EnvSinglePlayer.action_to_move(self, action, battle)
+    def action_to_order(self, action: np.int64, battle: AbstractBattle) -> BattleOrder:
+        return Gen7EnvSinglePlayer.action_to_order(self, action, battle)
 
     def describe_embedding(self) -> Space:
         pass
@@ -68,13 +68,13 @@ async def run_test_choose_move():
     battle._available_moves = [Move("flamethrower", gen=8)]
     # Test choosing a move
     message = await player.agent1.choose_move(battle)
-    order = player.action_to_move(np.int64(6), battle)
+    order = player.action_to_order(np.int64(6), battle)
     player.agent1.order_queue.put(order)
     assert message.message == "/choose move flamethrower"
     # Test switching Pokémon
     battle._available_switches = [Pokemon(species="charizard", gen=8)]
     message = await player.agent1.choose_move(battle)
-    order = player.action_to_move(np.int64(0), battle)
+    order = player.action_to_order(np.int64(0), battle)
     player.agent1.order_queue.put(order)
     assert message.message == "/choose switch charizard"
 
@@ -250,7 +250,7 @@ def test_action_space():
     "poke_env.environment.Pokemon.available_z_moves",
     new_callable=unittest.mock.PropertyMock,
 )
-def test_action_to_move(z_moves_mock):
+def test_action_to_order(z_moves_mock):
     for PlayerClass, (has_megas, has_z_moves, has_dynamax, has_tera) in zip(
         [
             Gen4EnvSinglePlayer,
@@ -285,12 +285,12 @@ def test_action_to_move(z_moves_mock):
 
         p = CustomEnvPlayerClass(start_listening=False, start_challenging=False)
         battle = Battle("bat1", p.agent1.username, p.agent1.logger, gen=8)
-        assert p.action_to_move(-1, battle).message == "/forfeit"
+        assert p.action_to_order(-1, battle).message == "/forfeit"
         battle._available_moves = [Move("flamethrower", gen=8)]
-        assert p.action_to_move(0, battle).message == "/choose move flamethrower"
+        assert p.action_to_order(0, battle).message == "/choose move flamethrower"
         battle._available_switches = [Pokemon(species="charizard", gen=8)]
         assert (
-            p.action_to_move(
+            p.action_to_order(
                 4
                 + (4 * int(has_megas))
                 + (4 * int(has_z_moves))
@@ -301,11 +301,11 @@ def test_action_to_move(z_moves_mock):
             == "/choose switch charizard"
         )
         battle._available_switches = []
-        assert p.action_to_move(3, battle).message == "/choose move flamethrower"
+        assert p.action_to_order(3, battle).message == "/choose move flamethrower"
         if has_megas:
             battle._can_mega_evolve = True
             assert (
-                p.action_to_move(4 + (4 * int(has_z_moves)), battle).message
+                p.action_to_order(4 + (4 * int(has_z_moves)), battle).message
                 == "/choose move flamethrower mega"
             )
         if has_z_moves:
@@ -315,18 +315,18 @@ def test_action_to_move(z_moves_mock):
             battle._team = {"charizard": active_pokemon}
             z_moves_mock.return_value = [Move("flamethrower", gen=8)]
             assert (
-                p.action_to_move(4, battle).message == "/choose move flamethrower zmove"
+                p.action_to_order(4, battle).message == "/choose move flamethrower zmove"
             )
             battle._team = {}
         if has_dynamax:
             battle._can_dynamax = True
             assert (
-                p.action_to_move(12, battle).message
+                p.action_to_order(12, battle).message
                 == "/choose move flamethrower dynamax"
             )
         if has_tera:
             battle._can_tera = True
             assert (
-                p.action_to_move(16, battle).message
+                p.action_to_order(16, battle).message
                 == "/choose move flamethrower terastallize"
             )

--- a/unit_tests/player/test_gymnasium.py
+++ b/unit_tests/player/test_gymnasium.py
@@ -21,7 +21,7 @@ class DummyEnv(GymnasiumEnv[ObsType]):
     ) -> float:
         return 69.42
 
-    def action_to_move(self, action: np.int64, battle: AbstractBattle) -> BattleOrder:
+    def action_to_order(self, action: np.int64, battle: AbstractBattle) -> BattleOrder:
         return ForfeitBattleOrder()
 
     def embed_battle(self, battle: AbstractBattle) -> ObsType:

--- a/unit_tests/player/test_gymnasium.py
+++ b/unit_tests/player/test_gymnasium.py
@@ -2,15 +2,16 @@ import asyncio
 import sys
 from io import StringIO
 
+import numpy as np
 from gymnasium import Space
-from pettingzoo.utils.env import ActionType, ObsType
+from pettingzoo.utils.env import ObsType
 
 from poke_env.environment import AbstractBattle, Battle, Pokemon
 from poke_env.player import BattleOrder, ForfeitBattleOrder, GymnasiumEnv
-from poke_env.player.gymnasium_api import _AsyncPlayer, _AsyncQueue
+from poke_env.player.gymnasium_api import _AsyncQueue, _EnvPlayer
 
 
-class DummyEnv(GymnasiumEnv[ObsType, ActionType]):
+class DummyEnv(GymnasiumEnv[ObsType]):
     def __init__(self, *args, **kwargs):
         self.opponent = None
         super().__init__(*args, **kwargs)
@@ -20,7 +21,7 @@ class DummyEnv(GymnasiumEnv[ObsType, ActionType]):
     ) -> float:
         return 69.42
 
-    def action_to_move(self, action: int, battle: AbstractBattle) -> BattleOrder:
+    def action_to_move(self, action: np.int64, battle: AbstractBattle) -> BattleOrder:
         return ForfeitBattleOrder()
 
     def embed_battle(self, battle: AbstractBattle) -> ObsType:
@@ -31,11 +32,6 @@ class DummyEnv(GymnasiumEnv[ObsType, ActionType]):
 
     def action_space_size(self) -> int:
         return 1
-
-
-class UserFuncs:
-    def embed_battle(self, battle):
-        return "battle"
 
 
 def test_init_queue():
@@ -63,12 +59,15 @@ def test_queue():
 
 
 def test_async_player():
-    player = _AsyncPlayer(UserFuncs(), start_listening=False, username="usr")
+    def embed_battle(battle):
+        return "battle"
+
+    player = _EnvPlayer(start_listening=False, username="usr")
     battle = Battle("bat1", player.username, player.logger, gen=8)
-    player.actions.put(-1)
+    player.order_queue.put(ForfeitBattleOrder())
     order = asyncio.get_event_loop().run_until_complete(player._env_move(battle))
     assert isinstance(order, ForfeitBattleOrder)
-    assert player.observations.get() == "battle"
+    assert embed_battle(player.battle_queue.get()) == "battle"
 
 
 def render(battle):


### PR DESCRIPTION
This should help some with the diff of #668.

We now do not pass in an instance of the environment into `_AsyncPlayer` (which is now renamed to `_EnvPlayer`), as there is no need to do that. So in step() for example, we now simply convert the action to an order in the env rather than in `_EnvPlayer`, pass the order to the `_EnvPlayer` via its `order_queue`, and then get the next battle object from its `battle_queue` and convert that to an embedding. Previously, all of that process was happening inside of `_EnvPlayer` by passing the entire environment into the player on initialization so it has access to the `action_to_order` and `embed_battle` methods, which doesn't sit well with me.