### PR TITLE
No more `describe_embedding`

### DIFF
--- a/docs/source/examples/rl_with_gymnasium_wrapper.rst
+++ b/docs/source/examples/rl_with_gymnasium_wrapper.rst
@@ -27,7 +27,7 @@ Observations are embeddings of the current state of the battle. They can be an a
 To define our observations, we will create a custom ``embed_battle`` method. It takes one argument, a ``Battle`` object, and returns our embedding.
 
 In addition to this, we also need to describe the embedding to the gymnasium interface.
-To achieve this, we need to implement the ``describe_embedding`` method where we specify the low bound and the high bound
+To achieve this, we need to initialize the ``observation_spaces`` field in the ``__init__`` method where we specify the low bound and the high bound
 for each component of the embedding vector and return them as a ``gymnasium.Space`` object.
 
 Defining rewards
@@ -58,6 +58,19 @@ Our player will play the ``gen8randombattle`` format. We can therefore inherit f
     from poke_env.player import Gen8EnvSinglePlayer
 
     class SimpleRLPlayer(Gen8EnvSinglePlayer):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            low = [-1, -1, -1, -1, 0, 0, 0, 0, 0, 0]
+            high = [3, 3, 3, 3, 4, 4, 4, 4, 1, 1]
+            self.observation_spaces = {
+                agent: Box(
+                    np.array(low, dtype=np.float32),
+                    np.array(high, dtype=np.float32),
+                    dtype=np.float32,
+                )
+                for agent in self.possible_agents
+            }
+
         def calc_reward(self, last_battle, current_battle) -> float:
             return self.reward_computing_helper(
                 current_battle, fainted_value=2.0, hp_value=1.0, victory_value=30.0
@@ -93,15 +106,6 @@ Our player will play the ``gen8randombattle`` format. We can therefore inherit f
                 ]
             )
             return np.float32(final_vector)
-
-        def describe_embedding(self) -> Space:
-            low = [-1, -1, -1, -1, 0, 0, 0, 0, 0, 0]
-            high = [3, 3, 3, 3, 4, 4, 4, 4, 1, 1]
-            return Box(
-                np.array(low, dtype=np.float32),
-                np.array(high, dtype=np.float32),
-                dtype=np.float32,
-            )
 
     ...
 

--- a/examples/gymnasium_example.py
+++ b/examples/gymnasium_example.py
@@ -15,10 +15,14 @@ from poke_env.player import (
 
 class TestEnv(GymnasiumEnv):
     def __init__(self, **kwargs):
-        self.opponent = RandomPlayer(
-            battle_format="gen8randombattle",
-            server_configuration=LocalhostServerConfiguration,
-        )
+        self.observation_spaces = {
+            agent: Box(
+                low=np.array([1, 1, float("-inf")]),
+                high=np.array([2, 4, float("+inf")]),
+                dtype=np.float64,
+            )
+            for agent in self.possible_agents
+        }
         super().__init__(**kwargs)
 
     def action_space_size(self):
@@ -27,24 +31,18 @@ class TestEnv(GymnasiumEnv):
     def embed_battle(self, battle):
         return np.array([1.0, 2.0, 3.0], dtype=np.float64)
 
-    def describe_embedding(self):
-        return Box(
-            low=np.array([1, 1, float("-inf")]),
-            high=np.array([2, 4, float("+inf")]),
-            dtype=np.float64,
-        )
-
     def action_to_move(self, action, battle):
         return self.agent.choose_random_move(battle)
 
     def calc_reward(self, last_battle, current_battle):
         return 0.25
 
-    def get_opponent(self):
-        return self.opponent
-
 
 class Gen8(Gen8EnvSinglePlayer):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.observation_spaces = {agent: Box(np.array([0, 0]), np.array([6, 6]), dtype=int) for agent in self.possible_agents}
+
     def calc_reward(self, last_battle, current_battle) -> float:
         return self.reward_computing_helper(current_battle)
 
@@ -61,9 +59,6 @@ class Gen8(Gen8EnvSinglePlayer):
                 fainted_enemy_mons += 1
         to_embed.append(fainted_enemy_mons)
         return np.array(to_embed)
-
-    def describe_embedding(self) -> Space:
-        return Box(np.array([0, 0]), np.array([6, 6]), dtype=int)
 
 
 def gymnasium_api():

--- a/examples/gymnasium_example.py
+++ b/examples/gymnasium_example.py
@@ -42,7 +42,10 @@ class TestEnv(GymnasiumEnv):
 class Gen8(Gen8EnvSinglePlayer):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.observation_spaces = {agent: Box(np.array([0, 0]), np.array([6, 6]), dtype=int) for agent in self.possible_agents}
+        self.observation_spaces = {
+            agent: Box(np.array([0, 0]), np.array([6, 6]), dtype=int)
+            for agent in self.possible_agents
+        }
 
     def calc_reward(self, battle) -> float:
         return self.reward_computing_helper(battle)

--- a/examples/rl_with_gymnasium_wrapper.py
+++ b/examples/rl_with_gymnasium_wrapper.py
@@ -24,6 +24,17 @@ from poke_env.player import (
 
 
 class SimpleRLPlayer(Gen8EnvSinglePlayer):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        low = [-1, -1, -1, -1, 0, 0, 0, 0, 0, 0]
+        high = [3, 3, 3, 3, 4, 4, 4, 4, 1, 1]
+        self.observation_spaces = {
+        agent: Box(
+            np.array(low, dtype=np.float32),
+            np.array(high, dtype=np.float32),
+            dtype=np.float32,
+        ) for agent in self.possible_agents}
+
     def calc_reward(self, last_battle, current_battle) -> float:
         return self.reward_computing_helper(
             current_battle, fainted_value=2.0, hp_value=1.0, victory_value=30.0
@@ -59,15 +70,6 @@ class SimpleRLPlayer(Gen8EnvSinglePlayer):
             ]
         )
         return np.float32(final_vector)
-
-    def describe_embedding(self) -> Space:
-        low = [-1, -1, -1, -1, 0, 0, 0, 0, 0, 0]
-        high = [3, 3, 3, 3, 4, 4, 4, 4, 1, 1]
-        return Box(
-            np.array(low, dtype=np.float32),
-            np.array(high, dtype=np.float32),
-            dtype=np.float32,
-        )
 
 
 async def main():

--- a/examples/rl_with_gymnasium_wrapper.py
+++ b/examples/rl_with_gymnasium_wrapper.py
@@ -29,11 +29,13 @@ class SimpleRLPlayer(Gen8EnvSinglePlayer):
         low = [-1, -1, -1, -1, 0, 0, 0, 0, 0, 0]
         high = [3, 3, 3, 3, 4, 4, 4, 4, 1, 1]
         self.observation_spaces = {
-        agent: Box(
-            np.array(low, dtype=np.float32),
-            np.array(high, dtype=np.float32),
-            dtype=np.float32,
-        ) for agent in self.possible_agents}
+            agent: Box(
+                np.array(low, dtype=np.float32),
+                np.array(high, dtype=np.float32),
+                dtype=np.float32,
+            )
+            for agent in self.possible_agents
+        }
 
     def calc_reward(self, battle) -> float:
         return self.reward_computing_helper(

--- a/integration_tests/test_env_player.py
+++ b/integration_tests/test_env_player.py
@@ -14,66 +14,72 @@ from poke_env.player import (
 
 
 class RandomGen4EnvPlayer(Gen4EnvSinglePlayer):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.observation_spaces = {agent: Box(np.array([0]), np.array([1]), dtype=int) for agent in self.possible_agents}
+
     def calc_reward(self, last_battle, current_battle) -> float:
         return 0.0
-
-    def describe_embedding(self) -> Space:
-        return Box(np.array([0]), np.array([1]), dtype=int)
 
     def embed_battle(self, battle):
         return np.array([0])
 
 
 class RandomGen5EnvPlayer(Gen5EnvSinglePlayer):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.observation_spaces = {agent: Box(np.array([0]), np.array([1]), dtype=int) for agent in self.possible_agents}
+
     def calc_reward(self, last_battle, current_battle) -> float:
         return 0.0
-
-    def describe_embedding(self) -> Space:
-        return Box(np.array([0]), np.array([1]), dtype=int)
 
     def embed_battle(self, battle):
         return np.array([0])
 
 
 class RandomGen6EnvPlayer(Gen6EnvSinglePlayer):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.observation_spaces = {agent: Box(np.array([0]), np.array([1]), dtype=int) for agent in self.possible_agents}
+
     def calc_reward(self, last_battle, current_battle) -> float:
         return 0.0
-
-    def describe_embedding(self) -> Space:
-        return Box(np.array([0]), np.array([1]), dtype=int)
 
     def embed_battle(self, battle):
         return np.array([0])
 
 
 class RandomGen7EnvPlayer(Gen7EnvSinglePlayer):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.observation_spaces = {agent: Box(np.array([0]), np.array([1]), dtype=int) for agent in self.possible_agents}
+
     def calc_reward(self, last_battle, current_battle) -> float:
         return 0.0
-
-    def describe_embedding(self) -> Space:
-        return Box(np.array([0]), np.array([1]), dtype=int)
 
     def embed_battle(self, battle):
         return np.array([0])
 
 
 class RandomGen8EnvPlayer(Gen8EnvSinglePlayer):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.observation_spaces = {agent: Box(np.array([0]), np.array([1]), dtype=int) for agent in self.possible_agents}
+
     def calc_reward(self, last_battle, current_battle) -> float:
         return 0.0
-
-    def describe_embedding(self) -> Space:
-        return Box(np.array([0]), np.array([1]), dtype=int)
 
     def embed_battle(self, battle):
         return np.array([0])
 
 
 class RandomGen9EnvPlayer(Gen9EnvSinglePlayer):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.observation_spaces = {agent: Box(np.array([0]), np.array([1]), dtype=int) for agent in self.possible_agents}
+
     def calc_reward(self, last_battle, current_battle) -> float:
         return 0.0
-
-    def describe_embedding(self) -> Space:
-        return Box(np.array([0]), np.array([1]), dtype=int)
 
     def embed_battle(self, battle):
         return np.array([0])

--- a/integration_tests/test_env_player.py
+++ b/integration_tests/test_env_player.py
@@ -16,7 +16,10 @@ from poke_env.player import (
 class RandomGen4EnvPlayer(Gen4EnvSinglePlayer):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.observation_spaces = {agent: Box(np.array([0]), np.array([1]), dtype=int) for agent in self.possible_agents}
+        self.observation_spaces = {
+            agent: Box(np.array([0]), np.array([1]), dtype=int)
+            for agent in self.possible_agents
+        }
 
     def calc_reward(self, last_battle, current_battle) -> float:
         return 0.0
@@ -28,7 +31,10 @@ class RandomGen4EnvPlayer(Gen4EnvSinglePlayer):
 class RandomGen5EnvPlayer(Gen5EnvSinglePlayer):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.observation_spaces = {agent: Box(np.array([0]), np.array([1]), dtype=int) for agent in self.possible_agents}
+        self.observation_spaces = {
+            agent: Box(np.array([0]), np.array([1]), dtype=int)
+            for agent in self.possible_agents
+        }
 
     def calc_reward(self, last_battle, current_battle) -> float:
         return 0.0
@@ -40,7 +46,10 @@ class RandomGen5EnvPlayer(Gen5EnvSinglePlayer):
 class RandomGen6EnvPlayer(Gen6EnvSinglePlayer):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.observation_spaces = {agent: Box(np.array([0]), np.array([1]), dtype=int) for agent in self.possible_agents}
+        self.observation_spaces = {
+            agent: Box(np.array([0]), np.array([1]), dtype=int)
+            for agent in self.possible_agents
+        }
 
     def calc_reward(self, last_battle, current_battle) -> float:
         return 0.0
@@ -52,7 +61,10 @@ class RandomGen6EnvPlayer(Gen6EnvSinglePlayer):
 class RandomGen7EnvPlayer(Gen7EnvSinglePlayer):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.observation_spaces = {agent: Box(np.array([0]), np.array([1]), dtype=int) for agent in self.possible_agents}
+        self.observation_spaces = {
+            agent: Box(np.array([0]), np.array([1]), dtype=int)
+            for agent in self.possible_agents
+        }
 
     def calc_reward(self, last_battle, current_battle) -> float:
         return 0.0
@@ -64,7 +76,10 @@ class RandomGen7EnvPlayer(Gen7EnvSinglePlayer):
 class RandomGen8EnvPlayer(Gen8EnvSinglePlayer):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.observation_spaces = {agent: Box(np.array([0]), np.array([1]), dtype=int) for agent in self.possible_agents}
+        self.observation_spaces = {
+            agent: Box(np.array([0]), np.array([1]), dtype=int)
+            for agent in self.possible_agents
+        }
 
     def calc_reward(self, last_battle, current_battle) -> float:
         return 0.0
@@ -76,7 +91,10 @@ class RandomGen8EnvPlayer(Gen8EnvSinglePlayer):
 class RandomGen9EnvPlayer(Gen9EnvSinglePlayer):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.observation_spaces = {agent: Box(np.array([0]), np.array([1]), dtype=int) for agent in self.possible_agents}
+        self.observation_spaces = {
+            agent: Box(np.array([0]), np.array([1]), dtype=int)
+            for agent in self.possible_agents
+        }
 
     def calc_reward(self, last_battle, current_battle) -> float:
         return 0.0

--- a/integration_tests/test_env_player.py
+++ b/integration_tests/test_env_player.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pytest
-from gymnasium.spaces import Box, Space
+from gymnasium.spaces import Box
 from pettingzoo.test.parallel_test import parallel_api_test
 
 from poke_env.player import (

--- a/src/poke_env/player/gymnasium_api.py
+++ b/src/poke_env/player/gymnasium_api.py
@@ -221,9 +221,6 @@ class GymnasiumEnv(ParallelEnv[str, ObsType, ActionType]):
         )
         self.agents: List[str] = []
         self.possible_agents = [self.agent1.username, self.agent2.username]
-        self.observation_spaces = {
-            name: self.describe_embedding() for name in self.possible_agents
-        }
         self.action_spaces = {
             name: Discrete(self.action_space_size()) for name in self.possible_agents
         }
@@ -369,10 +366,10 @@ class GymnasiumEnv(ParallelEnv[str, ObsType, ActionType]):
         )
         closing_task.result()
 
-    def observation_space(self, agent: str) -> Space:
+    def observation_space(self, agent: str) -> Space[ObsType]:
         return self.observation_spaces[agent]
 
-    def action_space(self, agent: str):
+    def action_space(self, agent: str) -> Space[ActionType]:
         return self.action_spaces[agent]
 
     ###################################################################################
@@ -421,17 +418,6 @@ class GymnasiumEnv(ParallelEnv[str, ObsType, ActionType]):
         :type battle: AbstractBattle
 
         :return: The embedding of the current battle state.
-        """
-        pass
-
-    @abstractmethod
-    def describe_embedding(self) -> Space[ObsType]:
-        """
-        Returns the description of the embedding. It must return a Space specifying
-        low bounds and high bounds.
-
-        :return: The description of the embedding.
-        :rtype: Space
         """
         pass
 

--- a/src/poke_env/player/gymnasium_api.py
+++ b/src/poke_env/player/gymnasium_api.py
@@ -356,7 +356,7 @@ class GymnasiumEnv(ParallelEnv[str, ObsType, np.int64]):
     def observation_space(self, agent: str) -> Space[ObsType]:
         return self.observation_spaces[agent]
 
-    def action_space(self, agent: str) -> Space[ActionType]:
+    def action_space(self, agent: str) -> Space:
         return self.action_spaces[agent]
 
     ###################################################################################

--- a/src/poke_env/player/gymnasium_api.py
+++ b/src/poke_env/player/gymnasium_api.py
@@ -356,7 +356,7 @@ class GymnasiumEnv(ParallelEnv[str, ObsType, np.int64]):
     def observation_space(self, agent: str) -> Space[ObsType]:
         return self.observation_spaces[agent]
 
-    def action_space(self, agent: str) -> Space:
+    def action_space(self, agent: str) -> Space[np.int64]:
         return self.action_spaces[agent]
 
     ###################################################################################

--- a/unit_tests/player/test_env_player.py
+++ b/unit_tests/player/test_env_player.py
@@ -31,9 +31,6 @@ class CustomEnvPlayer(EnvPlayer):
     def action_to_move(self, action: int, battle: AbstractBattle) -> BattleOrder:
         return Gen7EnvSinglePlayer.action_to_move(self, action, battle)
 
-    def describe_embedding(self) -> Space:
-        pass
-
     _ACTION_SPACE = Gen7EnvSinglePlayer._ACTION_SPACE
 
     def embed_battle(self, battle):
@@ -250,9 +247,6 @@ def test_action_space():
             def calc_reward(self, last_battle, current_battle):
                 return 0.0
 
-            def describe_embedding(self):
-                return None
-
         p = CustomEnvClass(start_listening=False, start_challenging=False)
 
         assert p.action_space(p.possible_agents[0]) == Discrete(
@@ -290,9 +284,6 @@ def test_action_to_move(z_moves_mock):
 
             def calc_reward(self, last_battle, current_battle):
                 return 0.0
-
-            def describe_embedding(self):
-                return None
 
             def get_opponent(self):
                 return None

--- a/unit_tests/player/test_env_player.py
+++ b/unit_tests/player/test_env_player.py
@@ -2,6 +2,7 @@ import asyncio
 import unittest
 from unittest.mock import patch
 
+import numpy as np
 from gymnasium.spaces import Discrete
 
 from poke_env import AccountConfiguration, ServerConfiguration

--- a/unit_tests/player/test_env_player.py
+++ b/unit_tests/player/test_env_player.py
@@ -3,7 +3,7 @@ import unittest
 from inspect import isawaitable
 from unittest.mock import patch
 
-from gymnasium.spaces import Discrete, Space
+from gymnasium.spaces import Discrete
 
 from poke_env import AccountConfiguration, ServerConfiguration
 from poke_env.environment import AbstractBattle, Battle, Move, Pokemon, Status

--- a/unit_tests/player/test_gymnasium.py
+++ b/unit_tests/player/test_gymnasium.py
@@ -12,7 +12,6 @@ from poke_env.player.gymnasium_api import _AsyncPlayer, _AsyncQueue
 
 class DummyEnv(GymnasiumEnv[ObsType, ActionType]):
     def __init__(self, *args, **kwargs):
-        self.opponent = None
         super().__init__(*args, **kwargs)
 
     def calc_reward(
@@ -25,9 +24,6 @@ class DummyEnv(GymnasiumEnv[ObsType, ActionType]):
 
     def embed_battle(self, battle: AbstractBattle) -> ObsType:
         return [0, 1, 2]
-
-    def describe_embedding(self) -> Space:
-        return "Space"
 
     def action_space_size(self) -> int:
         return 1

--- a/unit_tests/player/test_gymnasium.py
+++ b/unit_tests/player/test_gymnasium.py
@@ -2,6 +2,7 @@ import asyncio
 import sys
 from io import StringIO
 
+import numpy as np
 from pettingzoo.utils.env import ObsType
 
 from poke_env.environment import AbstractBattle, Battle, Pokemon

--- a/unit_tests/player/test_gymnasium.py
+++ b/unit_tests/player/test_gymnasium.py
@@ -2,7 +2,6 @@ import asyncio
 import sys
 from io import StringIO
 
-from gymnasium import Space
 from pettingzoo.utils.env import ActionType, ObsType
 
 from poke_env.environment import AbstractBattle, Battle, Pokemon


### PR DESCRIPTION
This should help ease down the diff of #668.

`describe_embedding` is no longer the way that the user informs the env class about the embedding space. The user will now do so inside of the `__init__` method by assigning the `observation_spaces` attribute.