### PR TITLE
ObservedPokemon enhancements, parse_battle_message fixes and StringBattleOrder

### DIFF
--- a/src/poke_env/environment/abstract_battle.py
+++ b/src/poke_env/environment/abstract_battle.py
@@ -523,7 +523,9 @@ class AbstractBattle(ABC):
                     )
             else:
                 pokemon, move, presumed_target = event[2:5]
-                if presumed_target == "":  # ['', 'move', 'p2a: 07ffb4c367', 'Teeter Dance', '', '[from] ability: Dancer']
+                if (
+                    presumed_target == ""
+                ):  # ['', 'move', 'p2a: 07ffb4c367', 'Teeter Dance', '', '[from] ability: Dancer']
                     pass
                 elif self.logger is not None:
                     self.logger.warning(
@@ -622,7 +624,9 @@ class AbstractBattle(ABC):
 
             if effect == "typechange":
                 if len(event) > 5 and event[5].startswith("[of] "):
-                    types = "/".join(map(lambda x: x.name, self.get_pokemon(event[5][5:]).types))
+                    types = "/".join(
+                        map(lambda x: x.name, self.get_pokemon(event[5][5:]).types)
+                    )
                 else:
                     types = event[4]
                 pokemon.start_effect(effect, details=types)  # type: ignore

--- a/src/poke_env/environment/abstract_battle.py
+++ b/src/poke_env/environment/abstract_battle.py
@@ -455,7 +455,7 @@ class AbstractBattle(ABC):
                 if override_move == "Sleep Talk":
                     # Sleep talk was used, but also reveals another move
                     reveal_other_move = True
-                elif override_move in {"Copycat", "Metronome", "Nature Power"}:
+                elif override_move in {"Copycat", "Metronome", "Nature Power", "Round"}:
                     pass
                 elif override_move in {"Grass Pledge", "Water Pledge", "Fire Pledge"}:
                     override_move = None
@@ -523,7 +523,9 @@ class AbstractBattle(ABC):
                     )
             else:
                 pokemon, move, presumed_target = event[2:5]
-                if self.logger is not None:
+                if presumed_target == "":  # ['', 'move', 'p2a: 07ffb4c367', 'Teeter Dance', '', '[from] ability: Dancer']
+                    pass
+                elif self.logger is not None:
                     self.logger.warning(
                         "Unmanaged move message format received - cleaned up message %s in "
                         "battle %s turn %d",
@@ -619,7 +621,11 @@ class AbstractBattle(ABC):
             pokemon = self.get_pokemon(pokemon)  # type: ignore
 
             if effect == "typechange":
-                pokemon.start_effect(effect, details=event[4])  # type: ignore
+                if len(event) > 5 and event[5].startswith("[of] "):
+                    types = "/".join(map(lambda x: x.name, self.get_pokemon(event[5][5:]).types))
+                else:
+                    types = event[4]
+                pokemon.start_effect(effect, details=types)  # type: ignore
             else:
                 pokemon.start_effect(effect)  # type: ignore
 
@@ -639,7 +645,7 @@ class AbstractBattle(ABC):
                 self.get_pokemon(target).start_effect(effect, event[4:6])
                 actor = event[6].replace("[of] ", "")
                 self.get_pokemon(actor).set_temporary_ability(event[5])
-            else:
+            elif target != "":  # ['', '-activate', '', 'move: Splash']
                 self.get_pokemon(target).start_effect(effect)
         elif event[1] == "-status":
             pokemon, status = event[2:4]

--- a/src/poke_env/environment/abstract_battle.py
+++ b/src/poke_env/environment/abstract_battle.py
@@ -732,7 +732,7 @@ class AbstractBattle(ABC):
                     self.get_pokemon(magician).item = to_id_str(item)
                     self.get_pokemon(magician).ability = to_id_str("magician")
                     self.get_pokemon(victim).item = None
-                elif cause in {"[from] move: Thief"}:
+                elif cause in {"[from] move: Thief", "[from] move: Covet"}:
                     thief = event[2]
                     victim = event[5].replace("[of] ", "")
                     item = event[3]

--- a/src/poke_env/environment/double_battle.py
+++ b/src/poke_env/environment/double_battle.py
@@ -511,7 +511,7 @@ class DoubleBattle(AbstractBattle):
         if isinstance(value, bool):
             self._opponent_can_mega_evolve = [value, value]
         else:
-            self._opponent_can_mega_evolve = value
+            self._opponent_can_mega_evolve = value  # type: ignore
 
     @property
     def opponent_can_z_move(self) -> List[bool]:
@@ -526,7 +526,7 @@ class DoubleBattle(AbstractBattle):
         if isinstance(value, bool):
             self._opponent_can_z_move = [value, value]
         else:
-            self._opponent_can_z_move = value
+            self._opponent_can_z_move = value  # type: ignore
 
     @property
     def trapped(self) -> List[bool]:

--- a/src/poke_env/environment/effect.py
+++ b/src/poke_env/environment/effect.py
@@ -77,6 +77,7 @@ class Effect(Enum):
     GLAIVE_RUSH = auto()
     GRAVITY = auto()
     GRUDGE = auto()
+    GUARD_DOG = auto()
     GUARD_SPLIT = auto()
     GULP_MISSILE = auto()
     G_MAX_CENTIFERNO = auto()
@@ -391,6 +392,7 @@ _FROM_ABILITY_EFFECTS: Set[Effect] = {
     Effect.FLASH_FIRE,
     Effect.FLOWER_VEIL,
     Effect.FOREWARN,
+    Effect.GUARD_DOG,
     Effect.GULP_MISSILE,
     Effect.HADRON_ENGINE,
     Effect.HEALER,
@@ -728,6 +730,7 @@ _ENDS_ON_MOVE_EFFECTS = {
     Effect.DESTINY_BOND,
     Effect.RAGE,
     Effect.INSTRUCT,
+    Effect.FOCUS_PUNCH,
 }
 
 _ENDS_ON_SWITCH_EFFECTS = {
@@ -768,6 +771,7 @@ _ENDS_ON_TURN_EFFECTS = {
     Effect.SPOTLIGHT,
     Effect.WIDE_GUARD,
     Effect.INSTRUCT,
+    Effect.FOCUS_PUNCH,
 }
 
 _ACTION_COUNTER_EFFECTS: Set[Effect] = {Effect.RAGE, Effect.STOCKPILE}
@@ -828,11 +832,13 @@ _FROM_DATA: Dict[str, Effect] = {
     "FLOWERVEIL": Effect.FLOWER_VEIL,
     "FOCUSBAND": Effect.FOCUS_BAND,
     "FOCUSENERGY": Effect.FOCUS_ENERGY,
+    "FOCUSPUNCH": Effect.FOCUS_PUNCH,
     "FOLLOWME": Effect.FOLLOW_ME,
     "FORESIGHT": Effect.FORESIGHT,
     "FOREWARN": Effect.FOREWARN,
     "FUTURESIGHT": Effect.FUTURE_SIGHT,
     "GASTROACID": Effect.GASTRO_ACID,
+    "GUARDDOG": Effect.GUARD_DOG,
     "GLAIVERUSH": Effect.GLAIVE_RUSH,
     "GRAVITY": Effect.GRAVITY,
     "GRUDGE": Effect.GRUDGE,

--- a/src/poke_env/environment/observation.py
+++ b/src/poke_env/environment/observation.py
@@ -22,8 +22,8 @@ class Observation:
     weather: Dict[Weather, int] = field(default_factory=dict)
     fields: Dict[Field, int] = field(default_factory=dict)
 
-    active_pokemon: Union[ObservedPokemon, None, List[ObservedPokemon]] = None
-    opponent_active_pokemon: Union[ObservedPokemon, List[ObservedPokemon], None] = None
+    active_pokemon: Union[ObservedPokemon, None, List[Optional[ObservedPokemon]]] = None
+    opponent_active_pokemon: Union[ObservedPokemon, List[Optional[ObservedPokemon]], None] = None
 
     # The player's team, so we can track states of mons throughout the battle
     team: Dict[str, Optional[ObservedPokemon]] = field(default_factory=dict)

--- a/src/poke_env/environment/observation.py
+++ b/src/poke_env/environment/observation.py
@@ -23,7 +23,9 @@ class Observation:
     fields: Dict[Field, int] = field(default_factory=dict)
 
     active_pokemon: Union[ObservedPokemon, None, List[Optional[ObservedPokemon]]] = None
-    opponent_active_pokemon: Union[ObservedPokemon, List[Optional[ObservedPokemon]], None] = None
+    opponent_active_pokemon: Union[
+        ObservedPokemon, List[Optional[ObservedPokemon]], None
+    ] = None
 
     # The player's team, so we can track states of mons throughout the battle
     team: Dict[str, Optional[ObservedPokemon]] = field(default_factory=dict)

--- a/src/poke_env/environment/observed_pokemon.py
+++ b/src/poke_env/environment/observed_pokemon.py
@@ -4,10 +4,10 @@ a more efficient serialization of a pokemon
 """
 
 import sys
+from collections import OrderedDict
 from copy import copy
 from dataclasses import dataclass, field
 from typing import Dict, List, Mapping, Optional, Union
-from collections import OrderedDict
 
 from poke_env.environment.effect import Effect
 from poke_env.environment.move import Move

--- a/src/poke_env/environment/observed_pokemon.py
+++ b/src/poke_env/environment/observed_pokemon.py
@@ -59,7 +59,7 @@ class ObservedPokemon:
         if self.stats:
             for stat in self.stats:
                 if isinstance(self.stats[stat], int):
-                    mon._stats[stat] = self.stats[stat]  # pyright: ignore
+                    mon._stats[stat] = self.stats[stat]  # type: ignore
 
         mon._gender = self.gender
         mon._shiny = self.shiny

--- a/src/poke_env/environment/observed_pokemon.py
+++ b/src/poke_env/environment/observed_pokemon.py
@@ -1,11 +1,13 @@
-"""This module defines the ObservedPokmon class, which stores
-what we have observed about a pokemon throughout a battle
+"""This module defines the ObservedPokemon class, which stores
+what we have observed about a pokemon throughout a battle, offering
+a more efficient serialization of a pokemon
 """
 
 import sys
 from copy import copy
 from dataclasses import dataclass, field
 from typing import Dict, List, Mapping, Optional, Union
+from collections import OrderedDict
 
 from poke_env.environment.effect import Effect
 from poke_env.environment.move import Move
@@ -19,6 +21,7 @@ from poke_env.environment.status import Status
 class ObservedPokemon:
     species: str
     level: int
+    name: str
 
     ability: Optional[str] = None
     boosts: Dict[str, int] = field(
@@ -38,11 +41,29 @@ class ObservedPokemon:
     is_terastallized: bool = False
     item: Optional[str] = None
     gender: Optional[PokemonGender] = None
-    moves: Dict[str, Move] = field(default_factory=dict)
+    moves: "OrderedDict[str, Move]" = field(default_factory=OrderedDict)
     tera_type: Optional[PokemonType] = None
     shiny: Optional[bool] = None
     stats: Optional[Mapping[str, Union[List[int], int, None]]] = None
     status: Optional[Status] = None
+
+    def to_pokemon(self, gen=9) -> Pokemon:
+        mon = Pokemon(gen=gen, species=self.species, name=self.name)
+        mon._item = self.item
+        mon._level = self.level
+        mon._moves = self.moves
+        mon._ability = self.ability
+        mon._terastallized_type = self.tera_type
+
+        mon._stats = {}
+        if self.stats:
+            for stat in self.stats:
+                if isinstance(self.stats[stat], int):
+                    mon._stats[stat] = self.stats[stat]  # pyright: ignore
+
+        mon._gender = self.gender
+        mon._shiny = self.shiny
+        return mon
 
     @staticmethod
     def initial_stats() -> Dict[str, List[int]]:
@@ -55,7 +76,7 @@ class ObservedPokemon:
         }
 
     @staticmethod
-    def from_pokemon(mon: Pokemon):
+    def from_pokemon(mon: Optional[Pokemon]):
         if mon is None:
             return None
 
@@ -68,6 +89,7 @@ class ObservedPokemon:
         return ObservedPokemon(
             species=mon.species,
             level=mon.level,
+            name=mon.name,
             ability=mon.ability,
             boosts={k: v for (k, v) in mon.boosts.items()},
             current_hp_fraction=mon.current_hp_fraction,
@@ -76,7 +98,7 @@ class ObservedPokemon:
             is_terastallized=mon.is_terastallized,
             item=mon.item,
             gender=mon.gender,
-            moves={k: copy(v) for (k, v) in mon.moves.items()},
+            moves=OrderedDict({k: copy(v) for (k, v) in mon.moves.items()}),
             tera_type=mon.tera_type,
             shiny=mon.shiny,
             stats=stats,

--- a/src/poke_env/environment/pokemon.py
+++ b/src/poke_env/environment/pokemon.py
@@ -402,7 +402,7 @@ class Pokemon:
         if effect.breaks_protect:
             self._protect_counter = 0
 
-        if effect == Effect.TYPECHANGE and details:
+        if effect == Effect.TYPECHANGE and details is not None:
             self._temporary_types = []
             for type_ in details.split("/"):
                 self._temporary_types.append(PokemonType.from_name(type_))

--- a/src/poke_env/environment/pokemon.py
+++ b/src/poke_env/environment/pokemon.py
@@ -787,7 +787,7 @@ class Pokemon:
     @property
     def fainted(self) -> bool:
         """
-        :return: Wheter the pokemon has fainted.
+        :return: Whether the pokemon has fainted.
         :rtype: bool
         """
         return Status.FNT == self._status
@@ -795,7 +795,7 @@ class Pokemon:
     @property
     def first_turn(self) -> bool:
         """
-        :return: Wheter this is this pokemon's first action since its last switch in.
+        :return: Whether this is this pokemon's first action since its last switch in.
         :rtype: bool
         """
         return self._first_turn

--- a/src/poke_env/player/battle_order.py
+++ b/src/poke_env/player/battle_order.py
@@ -54,6 +54,15 @@ class DefaultBattleOrder(BattleOrder):
         return self.DEFAULT_ORDER
 
 
+class StringBattleOrder(BattleOrder):
+    def __init__(self, string: str):
+        self._message = string
+
+    @property
+    def message(self) -> str:
+        return self._message
+
+
 @dataclass
 class DoubleBattleOrder(BattleOrder):
     def __init__(


### PR DESCRIPTION
Submitting these to get your comments! Would you like me to split these up and/or add unit_tests for sample logs of these? This PR is an accumulation of small changes:
1. Added support for Round, Splash and Covet
2. Considered edge-cases where Dancer copies Teeter Dance
3. Added support for typechange for [reflect type](https://github.com/smogon/pokemon-showdown/blob/101e221dd58e364278fc1e23dab9a388e6c22de6/data/moves.ts#L15428)
4. Added Effects for Focus Punch and Guard Dog, which weren't supported before
5. Fixed Typing error for Observations, where battle.active_pokemon should be a list of None or ObservedPokemon in Doubles (to map to battel.active_pokemon where the list is either None or Pokemon)
6. Added convenience function to create Pokemon from ObservedPokemon (for battle simulations)
7. Changed storage of Moves to OrderedDict. This is important because the order of moves that come in from a request affects acceptable protocol (e.g. you can submit "/choose move 1" which will correspond to the first move in the request)
8. Added name support for converting a Pokemon into an ObservedPokemon; this way we can find the relevant ObservedPokemon in the battle logs (where the identifier is the name)
9. Added a StringBattleOrder as a convenience BattleOrder if a user wants to manually create orders

If you want me to split them up, I can split into:
1. Observed Pokemon enhancements (5, 6, 7, 8)
2. Parsing errors (1, 2, 3, 4)
3. StringBattleOrder (if you want it; don't feel wedded to this -- this is just a convenience subclass for those wanting to use LLMs or have an agent they can manually control)