### PR TITLE
Replace `Snow` with `Snowscape`

### DIFF
--- a/src/poke_env/environment/weather.py
+++ b/src/poke_env/environment/weather.py
@@ -15,7 +15,7 @@ class Weather(Enum):
     PRIMORDIALSEA = auto()
     RAINDANCE = auto()
     SANDSTORM = auto()
-    SNOW = auto()
+    SNOWSCAPE = auto()
     SUNNYDAY = auto()
 
     def __str__(self) -> str:


### PR DESCRIPTION
Resolves compatibility issues created by https://github.com/smogon/pokemon-showdown/commit/deda1db857f5261c470bd262da7a5fd69f3b78e8

Alternatively, we can edit the `fromshowdownmessage` method to try and turn messages that are read in as "Snowscape" to also return `Weather.SNOW`, which would maintain compatibility with older builds of the Showdown server.