### PR TITLE
Fix Reflect Type/Heart Swap errors

### DIFF
--- a/src/poke_env/environment/abstract_battle.py
+++ b/src/poke_env/environment/abstract_battle.py
@@ -797,11 +797,19 @@ class AbstractBattle(ABC):
             source, target, stats = event[2:5]
             source_mon = self.get_pokemon(source)
             target_mon = self.get_pokemon(target)
-            for stat in stats.split(", "):
-                source_mon.boosts[stat], target_mon.boosts[stat] = (
-                    target_mon.boosts[stat],
-                    source_mon.boosts[stat],
-                )
+            if "[from]" in stats:
+                all_stats = ["accuracy", "atk", "def", "evasion", "spa", "spd", "spe"]
+                for stat in all_stats:
+                    source_mon.boosts[stat], target_mon.boosts[stat] = (
+                        target_mon.boosts[stat],
+                        source_mon.boosts[stat],
+                    )
+            else:
+                for stat in stats.split(", "):
+                    source_mon.boosts[stat], target_mon.boosts[stat] = (
+                        target_mon.boosts[stat],
+                        source_mon.boosts[stat],
+                    )
         elif event[1] == "-transform":
             pokemon, into = event[2:4]
             self.get_pokemon(pokemon).transform(self.get_pokemon(into))


### PR DESCRIPTION
I was playing around with this library (what do they call them in Python? "packages"? "modules"?) and I discovered an issue with the moves Reflect Type and Heart Swap. Judging by issue #708, it seems I'm not the first person to encounter this. I wanted to fix it myself so I could continue with the project I was using poke-env for, and once I had I figured I may as well submit a PR.
Not sure if this is the ideal way to do it, but it does fix the issue, and appears to do so without presenting any new problems.