### PR TITLE
Adding original_types as a property to Pokemon

### DIFF
--- a/src/poke_env/environment/abstract_battle.py
+++ b/src/poke_env/environment/abstract_battle.py
@@ -6,10 +6,12 @@ from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 from poke_env.data import GenData, to_id_str
 from poke_env.data.replay_template import REPLAY_TEMPLATE
+from poke_env.environment.effect import Effect
 from poke_env.environment.field import Field
 from poke_env.environment.observation import Observation
 from poke_env.environment.observed_pokemon import ObservedPokemon
 from poke_env.environment.pokemon import Pokemon
+from poke_env.environment.pokemon_type import PokemonType
 from poke_env.environment.side_condition import STACKABLE_CONDITIONS, SideCondition
 from poke_env.environment.weather import Weather
 
@@ -409,6 +411,23 @@ class AbstractBattle(ABC):
                 f.write(formatted_replay)
 
         self._finished = True
+
+    def is_grounded(self, mon: Pokemon):
+        if Field.GRAVITY in self.fields:
+            return True
+        elif mon.item == "ironball":
+            return True
+        elif mon.ability == "levitate":
+            return False
+        elif mon.ability is None and "levitate" in mon.possible_abilities:
+            return False
+        elif mon.item == "airballoon":
+            return False
+        elif mon.type_1 == PokemonType.FLYING or mon.type_2 == PokemonType.FLYING:
+            return False
+        elif Effect.MAGNET_RISE in mon.effects:
+            return False
+        return True
 
     def parse_message(self, split_message: List[str]):
         self._current_observation.events.append(split_message)
@@ -1096,6 +1115,11 @@ class AbstractBattle(ABC):
         :rtype: int
         """
         return self._gen
+
+    @property
+    @abstractmethod
+    def grounded(self) -> Any:
+        pass
 
     @property
     def last_request(self) -> Dict[str, Any]:

--- a/src/poke_env/environment/battle.py
+++ b/src/poke_env/environment/battle.py
@@ -226,6 +226,14 @@ class Battle(AbstractBattle):
         return self._force_switch
 
     @property
+    def grounded(self) -> bool:
+        """
+        :return: A boolean indicating whether the active pokemon is grounded
+        :rtype: bool
+        """
+        return self.is_grounded(self.active_pokemon) if self.active_pokemon else True
+
+    @property
     def maybe_trapped(self) -> bool:
         """
         :return: A boolean indicating whether the active pokemon is maybe trapped by the

--- a/src/poke_env/environment/double_battle.py
+++ b/src/poke_env/environment/double_battle.py
@@ -461,6 +461,14 @@ class DoubleBattle(AbstractBattle):
         return self._force_switch
 
     @property
+    def grounded(self) -> List[bool]:
+        """
+        :return: A boolean indicating whether the active pokemon are grounded
+        :rtype: List[bool]
+        """
+        return [self.is_grounded(mon) if mon else True for mon in self.active_pokemon]
+
+    @property
     def maybe_trapped(self) -> List[bool]:
         """
         :return: A boolean indicating whether either active pokemon is maybe trapped

--- a/src/poke_env/environment/effect.py
+++ b/src/poke_env/environment/effect.py
@@ -742,6 +742,7 @@ _ENDS_ON_SWITCH_EFFECTS = {
     Effect.PERISH1,
     Effect.PERISH2,
     Effect.PERISH3,
+    Effect.FLASH_FIRE,
 }
 
 _ENDS_ON_TURN_EFFECTS = {

--- a/src/poke_env/environment/pokemon.py
+++ b/src/poke_env/environment/pokemon.py
@@ -826,6 +826,15 @@ class Pokemon:
         """
         return self._heightm
 
+    def identifier(self, player_role: str) -> str:
+        """ "
+        :param player_role: The player's role in the battle (p1 or p2)
+        :type player_role: str
+        :return: The pokemon's identifier, which can be used to identify it in Showdown logs
+        """
+        assert player_role in ["p1", "p2"]
+        return player_role + ": " + self.name
+
     @property
     def is_dynamaxed(self) -> bool:
         """

--- a/src/poke_env/environment/pokemon.py
+++ b/src/poke_env/environment/pokemon.py
@@ -329,12 +329,22 @@ class Pokemon:
         # Handle silent effect ending
         if Effect.GLAIVE_RUSH in self.effects:
             self.end_effect("Glaive Rush")
-        if (
+        elif (
             Effect.CHARGE in self.effects
             and isinstance(move, Move)
+            and move.base_power > 0
             and move.type == PokemonType.ELECTRIC
+            and use
         ):
             self.end_effect("Charge")
+        elif (
+            Effect.FLASH_FIRE in self.effects
+            and isinstance(move, Move)
+            and move.base_power > 0
+            and move.type == PokemonType.FIRE
+            and use
+        ):
+            self.end_effect("Flash Fire")
 
     def prepare(self, move_id: str, target: Optional[Pokemon]):
         self.moved(move_id, use=False)
@@ -842,7 +852,7 @@ class Pokemon:
 
     @item.setter
     def item(self, item: Optional[str]):
-        self._item = item
+        self._item = to_id_str(item) if item is not None else None
 
     @property
     def level(self) -> int:
@@ -897,6 +907,13 @@ class Pokemon:
                 return dex_entry["name"]
             else:
                 return dex_entry["baseSpecies"]
+
+    @property
+    def original_types(self) -> List[PokemonType]:
+        if self._type_2 is None:
+            return [self._type_1]
+        else:
+            return [self._type_1, self._type_2]
 
     @property
     def pokeball(self) -> Optional[str]:

--- a/unit_tests/environment/test_battle.py
+++ b/unit_tests/environment/test_battle.py
@@ -462,6 +462,9 @@ def test_battle_request_and_interactions(example_request):
     assert not battle.maybe_trapped
     assert battle.opponent_can_dynamax
 
+    assert battle.grounded
+    assert battle.is_grounded(battle.opponent_active_pokemon)
+
     # Items
     battle.parse_message(
         [

--- a/unit_tests/environment/test_double_battle.py
+++ b/unit_tests/environment/test_double_battle.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from poke_env.environment import DoubleBattle, Move, Pokemon
+from poke_env.environment import DoubleBattle, Move, Pokemon, PokemonType, Field, Effect
 
 
 def test_battle_request_parsing(example_doubles_request):
@@ -385,3 +385,44 @@ def test_pledge_moves():
 
     assert "grasspledge" not in battle.team["p2: Primarina"].moves
     assert "waterpledge" in battle.team["p2: Primarina"].moves
+
+
+def test_is_grounded():
+    gen = 9
+    battle = DoubleBattle("tag", "username", MagicMock(), gen=gen)
+    battle.player_role = "p1"
+    furret = Pokemon(gen=9, species="furret")
+    battle.team = {"p1: Furret": furret}
+
+    battle.parse_message(["", "switch", "p1a: Furret", "Furret, L50, F", "100/100"],)
+    assert battle.grounded == [True, True]
+
+    furret._type_2 = PokemonType.FLYING
+    assert battle.grounded == [False, True]
+
+    furret._type_2 = None
+    furret._ability = "levitate"
+    assert battle.grounded == [False, True]
+
+    furret._ability = "frisk"
+    assert battle.grounded == [True, True]
+
+    furret._effects = {Effect.MAGNET_RISE: 1}
+    assert battle.grounded == [False, True]
+
+    furret._effects = {}
+    furret.item = "airballoon"
+    assert battle.grounded == [False, True]
+
+    battle._fields = {Field.GRAVITY: 1}
+    assert battle.grounded == [True, True]
+
+    furret._ability = "levitate"
+    assert battle.grounded == [True, True]
+
+    battle._fields = {}
+    assert battle.grounded == [False, True]
+
+    furret.item = "ironball"
+    assert battle.grounded == [True, True]
+    assert battle.is_grounded(furret)

--- a/unit_tests/environment/test_pokemon.py
+++ b/unit_tests/environment/test_pokemon.py
@@ -79,7 +79,7 @@ def test_powerherb_ends_move_preparation():
     mon = Pokemon(species="roserade", gen=8)
     mon.item = "powerherb"
 
-    mon.prepare("solarbeam", "talonflame")
+    mon.prepare("solarbeam", None)
     assert mon.preparing
 
     mon.end_item("powerherb")
@@ -177,6 +177,9 @@ def test_tera_type():
     assert charizard.tera_type is None
     charizard.terastallize("bug")
     assert charizard.tera_type == PokemonType.BUG
+    assert charizard.types == [PokemonType.BUG]
+    assert PokemonType.FIRE in charizard.original_types
+    assert PokemonType.FLYING in charizard.original_types
 
 
 def test_details():

--- a/unit_tests/environment/test_pokemon.py
+++ b/unit_tests/environment/test_pokemon.py
@@ -273,6 +273,8 @@ def test_name(example_doubles_request):
     assert mon.species == "zamazentacrowned"
     assert mon.name == "Nickname"
 
+    assert mon.identifier("p1") == "p1: Nickname"
+
 
 def test_stats(example_request, showdown_format_teams):
     request_mons = example_request["side"]["pokemon"]


### PR DESCRIPTION
Did four things:
1. Added support for `original_types`. This allows us to correctly calculate damage offensively with tera types, and defensively with stellar
2. Added appropriate handling for Flash Fire and Charge, according to their trigger conditions
3. Added support for identifying whether a pokemon is grounded
4. Added support for creating a mon's identifier

The last is totally not necessary, but is useful abstraction from showdown's logs, and matches well with the descriptions of `battle.team` and `opponent_team` which already refer to identifiers, but don't provide details on what an identifier is. All of these will unblock damage calc, which I will add next