### PR TITLE
Fix docstrings across repository

### DIFF
--- a/src/poke_env/battle/abstract_battle.py
+++ b/src/poke_env/battle/abstract_battle.py
@@ -1352,12 +1352,11 @@ class AbstractBattle(ABC):
 
     @players.setter
     def players(self, players: Tuple[str, str]):
-        """Sets the battle player's name:
+        """Set the players' usernames.
 
-        :param player_1: First player's username.
-        :type player_1: str
-        :param player_1: Second player's username.
-        :type player_2: str
+        :param players: Tuple containing the player's username and the
+            opponent's username.
+        :type players: Tuple[str, str]
         """
         player_1, player_2 = players
         if player_1 != self._player_username:

--- a/src/poke_env/battle/double_battle.py
+++ b/src/poke_env/battle/double_battle.py
@@ -261,6 +261,8 @@ class DoubleBattle(AbstractBattle):
 
         :param move: Move instance for which possible targets should be returned
         :type move: Move
+        :param pokemon: The ally using the move.
+        :type pokemon: Pokemon
         :param dynamax: whether given move also STARTS dynamax for its user
         :return: a list of integers indicating Pokemon Showdown targets:
             -1, -2, 1, 2 or self.EMPTY_TARGET_POSITION that indicates "no target"

--- a/src/poke_env/calc/damage_calc_gen9.py
+++ b/src/poke_env/calc/damage_calc_gen9.py
@@ -35,11 +35,23 @@ def calculate_damage(
     battle: Union[Battle, DoubleBattle],
     is_critical: bool = False,
 ):
-    """
-    This function takes in an attacker and defender identifier, the move being used, the battle
-    object that contains the attacker and defender, and whether we should account for a crit. It returns
-    a tuple that contains minimum and maximum damage rolls possible. It doesn't deal with several edge-cases
-    noted in the file, generally noting where it deeviates from the official damage calculator.
+    """Return the possible damage range for a move.
+
+    :param attacker_identifier: Identifier of the attacking Pokémon.
+    :type attacker_identifier: str
+    :param defender_identifier: Identifier of the defending Pokémon.
+    :type defender_identifier: str
+    :param move: Move being used.
+    :type move: Move
+    :param battle: Current battle object containing both Pokémon.
+    :type battle: Battle or DoubleBattle
+    :param is_critical: Whether to compute damage for a critical hit.
+    :type is_critical: bool
+    :return: Tuple of minimum and maximum damage rolls.
+    :rtype: Tuple[int, int]
+    
+    Notes that several edge cases are ignored and behaviour may deviate from
+    the official damage calculator.
     """
     attacker = battle.get_pokemon(attacker_identifier)
     defender = battle.get_pokemon(defender_identifier)

--- a/src/poke_env/calc/damage_calc_gen9.py
+++ b/src/poke_env/calc/damage_calc_gen9.py
@@ -49,7 +49,7 @@ def calculate_damage(
     :type is_critical: bool
     :return: Tuple of minimum and maximum damage rolls.
     :rtype: Tuple[int, int]
-    
+
     Notes that several edge cases are ignored and behaviour may deviate from
     the official damage calculator.
     """

--- a/src/poke_env/environment/doubles_env.py
+++ b/src/poke_env/environment/doubles_env.py
@@ -87,8 +87,7 @@ class DoublesEnv(PokeEnv[ObsType, npt.NDArray[np.int64]]):
         fake: bool = False,
         strict: bool = True,
     ) -> BattleOrder:
-        """
-        Returns the BattleOrder relative to the given action.
+        """Convert an action array into a :class:`BattleOrder`.
 
         The action is a list in doubles, and the individual action mapping is
         as follows, where each 5-long range for a move corresponds to a
@@ -122,6 +121,12 @@ class DoublesEnv(PokeEnv[ObsType, npt.NDArray[np.int64]]):
         :type action: ndarray[int64]
         :param battle: The current battle state
         :type battle: AbstractBattle
+        :param fake: If ``True``, return a best-effort order even if it would be
+            illegal.
+        :type fake: bool
+        :param strict: If ``True``, raise an error when the action is illegal;
+            otherwise return a default order.
+        :type strict: bool
 
         :return: The battle order for the given action in context of the current battle.
         :rtype: BattleOrder
@@ -224,13 +229,18 @@ class DoublesEnv(PokeEnv[ObsType, npt.NDArray[np.int64]]):
         fake: bool = False,
         strict: bool = True,
     ) -> npt.NDArray[np.int64]:
-        """
-        Returns the action relative to the given BattleOrder.
+        """Convert a :class:`BattleOrder` into an action array.
 
         :param order: The order to take.
         :type order: BattleOrder
         :param battle: The current battle state
         :type battle: AbstractBattle
+        :param fake: If ``True``, return a best-effort action even if it would be
+            illegal.
+        :type fake: bool
+        :param strict: If ``True``, raise an error when the order is illegal;
+            otherwise return default.
+        :type strict: bool
 
         :return: The action for the given battle order in context of the current battle.
         :rtype: ndarray[int64]

--- a/src/poke_env/stats.py
+++ b/src/poke_env/stats.py
@@ -48,13 +48,15 @@ def _raw_hp(base: int, ev: int, iv: int, level: int) -> int:
 def compute_raw_stats(
     species: str, evs: List[int], ivs: List[int], level: int, nature: str, data: GenData
 ) -> List[int]:
-    """Converts to raw stats
-    :param species: pokemon species
-    :param evs: list of pokemon's EVs (size 6)
-    :param ivs: list of pokemon's IVs (size 6)
-    :param level: pokemon level
-    :param nature: pokemon nature
-    :return: the raw stats in order [hp, atk, def, spa, spd, spe]
+    """Compute raw stats for a Pokémon.
+
+    :param species: Pokémon species.
+    :param evs: List of EV values (size 6).
+    :param ivs: List of IV values (size 6).
+    :param level: Pokémon level.
+    :param nature: Pokémon nature.
+    :param data: ``GenData`` instance providing Pokédex information.
+    :return: Raw stats as ``[hp, atk, def, spa, spd, spe]``.
     """
 
     assert len(evs) == 6


### PR DESCRIPTION
## Summary
- correct param docs for `compute_raw_stats`
- document missing parameters for `DoublesEnv` action conversion helpers
- document missing parameter in `DoubleBattle.get_possible_showdown_targets`
- fix `AbstractBattle.players` setter docstring
- overhaul `calculate_damage` docstring

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'orjson')*

------
https://chatgpt.com/codex/tasks/task_b_6861c6184f5483309091949c50697550