### PR TITLE
Improve documentation coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ pip install .[dev]
 
 ## Acknowledgements
 
-This project is a follow-up of a group project from an artifical intelligence class at [Ecole Polytechnique](https://www.polytechnique.edu/).
+This project is a follow-up of a group project from an artificial intelligence class at [Ecole Polytechnique](https://www.polytechnique.edu/).
 
 You can find the original repository [here](https://github.com/hsahovic/inf581-project). It is partially inspired by the [showdown-battle-bot project](https://github.com/Synedh/showdown-battle-bot). Of course, none of these would have been possible without [Pokemon Showdown](https://github.com/Zarel/Pokemon-Showdown).
 

--- a/docs/source/examples/index.rst
+++ b/docs/source/examples/index.rst
@@ -3,7 +3,7 @@
 Examples
 ========
 
-This page lists detailled examples demonstrating how to use this package. They are meant to cover basic use cases.
+This page lists detailed examples demonstrating how to use this package. They are meant to cover basic use cases.
 
 .. toctree::
     :maxdepth: 4

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -25,6 +25,7 @@ It boasts a straightforward API for handling Pokémon, Battles, Moves, and other
    modules/player.rst
    modules/pokemon.rst
    modules/move.rst
+   modules/env.rst
    modules/other_environment.rst
 
 On top of the main modules dedicated to building Pokémon Showdown bots, Poke-env encompasses standalone submodules to cater to various facets of Pokémon Showdown interactions:
@@ -36,6 +37,9 @@ On top of the main modules dedicated to building Pokémon Showdown bots, Poke-en
    Data - Access and manipulate pokémon data <modules/data.rst>
    PS Client - Interact with Pokémon Showdown servers <modules/ps_client.rst>
    Teambuilder - Parse and generate showdown teams <modules/teambuilder.rst>
+   Concurrency utilities <modules/concurrency.rst>
+   Damage calculator <modules/calc.rst>
+   Exceptions <modules/exceptions.rst>
 
 Acknowledgements
 ================

--- a/docs/source/modules/calc.rst
+++ b/docs/source/modules/calc.rst
@@ -1,0 +1,9 @@
+.. _calc:
+
+Damage calculator
+=================
+
+.. automodule:: poke_env.calc.damage_calc_gen9
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/modules/concurrency.rst
+++ b/docs/source/modules/concurrency.rst
@@ -1,0 +1,9 @@
+.. _concurrency:
+
+Concurrency utilities
+=====================
+
+.. automodule:: poke_env.concurrency
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/modules/env.rst
+++ b/docs/source/modules/env.rst
@@ -8,7 +8,7 @@ The env object and related subclasses
 PokeEnv
 ******
 
-.. automodule:: poke_env.player.env
+.. automodule:: poke_env.environment.env
    :members:
    :undoc-members:
    :show-inheritance:
@@ -16,7 +16,23 @@ PokeEnv
 SinglesEnv
 *************
 
-.. automodule:: poke_env.player.singles_env
+.. automodule:: poke_env.environment.singles_env
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+DoublesEnv
+***********
+
+.. automodule:: poke_env.environment.doubles_env
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+SingleAgentWrapper
+******************
+
+.. automodule:: poke_env.environment.single_agent_wrapper
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/source/modules/exceptions.rst
+++ b/docs/source/modules/exceptions.rst
@@ -1,0 +1,9 @@
+.. _exceptions:
+
+Exceptions
+==========
+
+.. automodule:: poke_env.exceptions
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/modules/player.rst
+++ b/docs/source/modules/player.rst
@@ -13,10 +13,26 @@ Player
    :undoc-members:
    :show-inheritance:
 
-Random Player
+Baselines
+*********
+
+.. automodule:: poke_env.player.baselines
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Battle orders
 *************
 
-.. automodule:: poke_env.player.random_player
+.. automodule:: poke_env.player.battle_order
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Utilities
+*********
+
+.. automodule:: poke_env.player.utils
    :members:
    :undoc-members:
    :show-inheritance:


### PR DESCRIPTION
## Summary
- fix small typos in docs
- add env, concurrency, calc and exceptions documentation
- document baseline players and utilities
- include env page in module index

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'orjson')*

------
https://chatgpt.com/codex/tasks/task_b_6861c68ee9e083308ee7e564cfcbc54c