### PR TITLE
Fix error-handling bug regarding disabled moves

### DIFF
--- a/src/poke_env/player/player.py
+++ b/src/poke_env/player/player.py
@@ -377,11 +377,11 @@ class Player(ABC):
                 elif split_message[2].startswith(
                     "[Unavailable choice]"
                 ) and split_message[2].endswith("is disabled"):
-                    await self._handle_battle_request(battle, maybe_default_order=True)
+                    self._trying_again.set()
                 elif split_message[2].startswith("[Invalid choice]") and split_message[
                     2
                 ].endswith("is disabled"):
-                    await self._handle_battle_request(battle, maybe_default_order=True)
+                    self._trying_again.set()
                 elif split_message[2].startswith(
                     "[Invalid choice] Can't move: You sent more choices than unfainted"
                     " Pokémon."


### PR DESCRIPTION
`PS_ERROR` messages related to trying to use a move that is disabled are followed by request messages, something we aren't correctly handling. This is fixed here.