### PR TITLE
Fix berry tracking in case a berry is stolen and immediately eaten

### DIFF
--- a/src/poke_env/battle/abstract_battle.py
+++ b/src/poke_env/battle/abstract_battle.py
@@ -334,10 +334,10 @@ class AbstractBattle(ABC):
             pkmn_object = self.get_pokemon(pkmn)
             if (
                 pkmn_object.item is not None
+                # don't assign an item that was just consumed
                 and "berry" not in item
                 and "herb" not in item
             ):
-                # don't assign an item that was just consumed
                 pkmn_object.item = item
 
     def _check_heal_message_for_ability(self, split_message: List[str]):


### PR DESCRIPTION
This fixes an error where we assign a berry or herb item to a Pokemon when we see it has been "revealed" to be held by it, when in reality the Pokemon has just consumed that item.