### PR TITLE
Update python version for pyright in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ multi_line_output = 3
 
 [tool.pyright]
 include = ["src"]
-pythonVersion = "3.7"
+pythonVersion = "3.10"
 
 [tool.setuptools.dynamic]
 dependencies = { file = ["requirements.txt"] }


### PR DESCRIPTION
This gets rid of some lint errors I was seeing in my editor because my vscode uses pyright natively.