### PR TITLE
Fix: Gen 1-2: Crash when TeamBuilder.ability is None

### DIFF
--- a/src/poke_env/battle/pokemon.py
+++ b/src/poke_env/battle/pokemon.py
@@ -732,7 +732,7 @@ class Pokemon:
 
         if tb.level:
             self._level = tb.level
-        self._ability = to_id_str(tb.ability)
+        self._ability = to_id_str(tb.ability) if tb.ability is not None else None
         self._item = to_id_str(tb.item) if tb.item else None
         if tb.gender:
             self._gender = PokemonGender.from_request_details(tb.gender)

--- a/unit_tests/environment/test_pokemon.py
+++ b/unit_tests/environment/test_pokemon.py
@@ -2,6 +2,7 @@ from unittest.mock import MagicMock
 
 from poke_env.battle import DoubleBattle, Move, Pokemon, PokemonGender, PokemonType
 from poke_env.stats import _raw_hp, _raw_stat
+from poke_env.teambuilder import TeambuilderPokemon
 from poke_env.teambuilder.teambuilder import Teambuilder
 
 
@@ -338,6 +339,16 @@ def test_teambuilder(showdown_format_teams):
         "spd": 90,
         "spe": 80,
     }
+
+
+def test_teambuilder_without_ability_in_gen2():
+    tb_mon = TeambuilderPokemon(
+        species="snorlax", level=100, moves=["Body Slam"], ability=None
+    )
+
+    mon = Pokemon(2, teambuilder=tb_mon)
+
+    assert mon.ability is None
 
 
 def test_name(example_doubles_request):


### PR DESCRIPTION
Fix for https://github.com/hsahovic/poke-env/issues/843