### PR TITLE
Fix commander edge-case

### DIFF
--- a/src/poke_env/battle/abstract_battle.py
+++ b/src/poke_env/battle/abstract_battle.py
@@ -523,6 +523,9 @@ class AbstractBattle(ABC):
         replay_path.write_text(self._build_replay_html(), encoding="utf-8")
         return replay_path
 
+    def _clear_commander_from_partner(self, pokemon_identifier: str):
+        pass
+
     def _finish_battle(self):
         self._finished = True
 
@@ -759,15 +762,8 @@ class AbstractBattle(ABC):
         elif event[1] == "faint":
             mon = self.get_pokemon(event[2])
             mon.faint()
-            if mon.species == "dondozo" and isinstance(self.active_pokemon, list):
-                active_mons = (
-                    self.active_pokemon
-                    if event[2][:2] == self.player_role
-                    else self.opponent_active_pokemon
-                )
-                other = active_mons[1 if event[2][2] == "a" else 0]
-                if other is not None and Effect.COMMANDER in other.effects:
-                    other.end_effect("Commander")
+            if mon.species == "dondozo":
+                self._clear_commander_from_partner(event[2][:3])
         elif event[1] == "-unboost":
             pokemon, stat, amount = event[2:5]
             self.get_pokemon(pokemon).boost(stat, -int(amount))

--- a/src/poke_env/battle/double_battle.py
+++ b/src/poke_env/battle/double_battle.py
@@ -58,6 +58,16 @@ class DoubleBattle(AbstractBattle):
                 if active_pokemon is not None:
                     active_pokemon.clear_boosts()
 
+    def _clear_commander_from_partner(self, pokemon_identifier: str):
+        active_mons = (
+            self.active_pokemon
+            if pokemon_identifier[:2] == self.player_role
+            else self.opponent_active_pokemon
+        )
+        other = active_mons[1 if pokemon_identifier[2] == "a" else 0]
+        if other is not None and Effect.COMMANDER in other.effects:
+            other.end_effect("Commander")
+
     def end_illusion(self, pokemon_name: str, details: str):
         player_identifier = pokemon_name[:2]
         pokemon_identifier = pokemon_name[:3]
@@ -258,14 +268,7 @@ class DoubleBattle(AbstractBattle):
         if pokemon_out is not None:
             pokemon_out.switch_out(self.fields)
             if pokemon_out.species == "dondozo":
-                partner_key = (
-                    f"{player_identifier}b"
-                    if pokemon_identifier[2] == "a"
-                    else f"{player_identifier}a"
-                )
-                partner = team.get(partner_key)
-                if partner is not None and Effect.COMMANDER in partner.effects:
-                    partner.end_effect("Commander")
+                self._clear_commander_from_partner(pokemon_identifier)
         pokemon_in = self.get_pokemon(pokemon_str, details=details)
         pokemon_in.switch_in()
         pokemon_in.set_hp_status(hp_status)

--- a/src/poke_env/battle/double_battle.py
+++ b/src/poke_env/battle/double_battle.py
@@ -257,6 +257,15 @@ class DoubleBattle(AbstractBattle):
         pokemon_out = team.pop(pokemon_identifier, None)
         if pokemon_out is not None:
             pokemon_out.switch_out(self.fields)
+            if pokemon_out.species == "dondozo":
+                partner_key = (
+                    f"{player_identifier}b"
+                    if pokemon_identifier[2] == "a"
+                    else f"{player_identifier}a"
+                )
+                partner = team.get(partner_key)
+                if partner is not None and Effect.COMMANDER in partner.effects:
+                    partner.end_effect("Commander")
         pokemon_in = self.get_pokemon(pokemon_str, details=details)
         pokemon_in.switch_in()
         pokemon_in.set_hp_status(hp_status)

--- a/unit_tests/environment/test_double_battle.py
+++ b/unit_tests/environment/test_double_battle.py
@@ -613,6 +613,41 @@ def test_dondozo_tatsugiri():
     assert Effect.COMMANDER not in tatsu.effects
 
 
+def test_dondozo_tatsugiri_switch_out():
+    battle = DoubleBattle("tag", "username", MagicMock(), gen=9)
+    battle.player_role = "p1"
+    dozo = Pokemon(gen=9, species="dondozo")
+    battle.team = {"p1: Dondozo": dozo}
+    tatsu = Pokemon(gen=9, species="tatsugiri")
+    tatsu._ability = "commander"
+    battle.team["p1: Tatsugiri"] = tatsu
+    urshifu = Pokemon(gen=9, species="urshifu")
+    battle.team["p1: Urshifu"] = urshifu
+
+    # Start with Dondozo at p1a, Urshifu at p1b
+    battle.parse_message(["", "switch", "p1a: Dondozo", "Dondozo, L50, M", "100/100"])
+    battle.parse_message(["", "switch", "p1b: Urshifu", "Urshifu, L50, M", "100/100"])
+
+    # Turn 1: Tatsugiri switches in at p1b, Commander activates
+    battle.parse_message(
+        ["", "switch", "p1b: Tatsugiri", "Tatsugiri, L50, M", "100/100"]
+    )
+    battle.parse_message(
+        ["", "-activate", "p1b: Tatsugiri", "ability: Commander", "[of] p1a: Dondozo"]
+    )
+    assert Effect.COMMANDER in tatsu.effects
+
+    # Dondozo switches out at p1a, replaced by Flutter Mane
+    flutter = Pokemon(gen=9, species="fluttermane")
+    battle.team["p1: Flutter Mane"] = flutter
+    battle.parse_message(
+        ["", "switch", "p1a: Flutter Mane", "Flutter Mane, L50", "100/100"]
+    )
+
+    # Commander effect should be cleared from Tatsugiri
+    assert Effect.COMMANDER not in tatsu.effects
+
+
 def test_symbiosis():
     battle = DoubleBattle("tag", "username", MagicMock(), gen=9)
     battle.player_role = "p1"


### PR DESCRIPTION
The action space would sometimes incorrectly claim that Tatsugiri has no legal moves if it switches in on the same turn that dondozo switches out. This is because Tatsugiri's Commander ability wasn't being correctly turned off. This PR fixes that.