### PR TITLE
Performance improvements

### DIFF
--- a/src/poke_env/battle/double_battle.py
+++ b/src/poke_env/battle/double_battle.py
@@ -320,12 +320,10 @@ class DoubleBattle(AbstractBattle):
             return [self.EMPTY_TARGET_POSITION]
 
         pokemon_1, pokemon_2 = self.active_pokemon
-        if pokemon == pokemon_1 and move.id in [m.id for m in self.available_moves[0]]:
+        if pokemon is pokemon_1:
             self_position = self.POKEMON_1_POSITION
             ally_position = self.POKEMON_2_POSITION
-        elif pokemon == pokemon_2 and move.id in [
-            m.id for m in self.available_moves[1]
-        ]:
+        elif pokemon is pokemon_2:
             self_position = self.POKEMON_2_POSITION
             ally_position = self.POKEMON_1_POSITION
         else:

--- a/src/poke_env/battle/double_battle.py
+++ b/src/poke_env/battle/double_battle.py
@@ -14,6 +14,24 @@ from poke_env.player.battle_order import (
     SingleBattleOrder,
 )
 
+_SHOWDOWN_TARGET_SLOTS = {
+    "ADJACENT_ALLY": ["ally"],
+    "ADJACENT_ALLY_OR_SELF": ["ally", "self"],
+    "ADJACENT_FOE": ["opp1", "opp2"],
+    "ALL": ["empty"],
+    "ALL_ADJACENT": ["empty"],
+    "ALL_ADJACENT_FOES": ["empty"],
+    "ALLIES": ["empty"],
+    "ALLY_SIDE": ["empty"],
+    "ALLY_TEAM": ["empty"],
+    "ANY": ["ally", "opp1", "opp2"],
+    "FOE_SIDE": ["empty"],
+    "NORMAL": ["ally", "opp1", "opp2"],
+    "RANDOM_NORMAL": ["empty"],
+    "SCRIPTED": ["empty"],
+    "SELF": ["empty"],
+}
+
 
 class DoubleBattle(AbstractBattle):
     POKEMON_1_POSITION = -1
@@ -337,9 +355,7 @@ class DoubleBattle(AbstractBattle):
                 targets = [self.EMPTY_TARGET_POSITION]
             else:
                 targets = [self.OPPONENT_1_POSITION, self.OPPONENT_2_POSITION]
-        elif move.non_ghost_target and (
-            PokemonType.GHOST not in pokemon.types
-        ):  # fixing target for Curse
+        elif move.non_ghost_target and PokemonType.GHOST not in pokemon.types:
             targets = [self.EMPTY_TARGET_POSITION]
         elif move.id == "pollenpuff" and Effect.HEAL_BLOCK in pokemon.effects:
             targets = [self.OPPONENT_1_POSITION, self.OPPONENT_2_POSITION]
@@ -351,45 +367,18 @@ class DoubleBattle(AbstractBattle):
         ):
             targets = [self.EMPTY_TARGET_POSITION]
         else:
-            targets = {
-                Target.from_showdown_message("adjacentAlly"): [ally_position],
-                Target.from_showdown_message("adjacentAllyOrSelf"): [
-                    ally_position,
-                    self_position,
-                ],
-                Target.from_showdown_message("adjacentFoe"): [
-                    self.OPPONENT_1_POSITION,
-                    self.OPPONENT_2_POSITION,
-                ],
-                Target.from_showdown_message("all"): [self.EMPTY_TARGET_POSITION],
-                Target.from_showdown_message("allAdjacent"): [
-                    self.EMPTY_TARGET_POSITION
-                ],
-                Target.from_showdown_message("allAdjacentFoes"): [
-                    self.EMPTY_TARGET_POSITION
-                ],
-                Target.from_showdown_message("allies"): [self.EMPTY_TARGET_POSITION],
-                Target.from_showdown_message("allySide"): [self.EMPTY_TARGET_POSITION],
-                Target.from_showdown_message("allyTeam"): [self.EMPTY_TARGET_POSITION],
-                Target.from_showdown_message("any"): [
-                    ally_position,
-                    self.OPPONENT_1_POSITION,
-                    self.OPPONENT_2_POSITION,
-                ],
-                Target.from_showdown_message("foeSide"): [self.EMPTY_TARGET_POSITION],
-                Target.from_showdown_message("normal"): [
-                    ally_position,
-                    self.OPPONENT_1_POSITION,
-                    self.OPPONENT_2_POSITION,
-                ],
-                Target.from_showdown_message("randomNormal"): [
-                    self.EMPTY_TARGET_POSITION
-                ],
-                Target.from_showdown_message("scripted"): [self.EMPTY_TARGET_POSITION],
-                Target.from_showdown_message("self"): [self.EMPTY_TARGET_POSITION],
-                self.EMPTY_TARGET_POSITION: [self.EMPTY_TARGET_POSITION],
-                None: [self.OPPONENT_1_POSITION, self.OPPONENT_2_POSITION],
-            }[move.deduced_target]
+            slot_map = {
+                "self": self_position,
+                "ally": ally_position,
+                "opp1": self.OPPONENT_1_POSITION,
+                "opp2": self.OPPONENT_2_POSITION,
+                "empty": self.EMPTY_TARGET_POSITION,
+            }
+            if move.deduced_target is None:
+                targets = [self.OPPONENT_1_POSITION, self.OPPONENT_2_POSITION]
+            else:
+                slots = _SHOWDOWN_TARGET_SLOTS[move.deduced_target.name]
+                targets = [slot_map[s] for s in slots]
 
         pokemon_ids = set(self._opponent_active_pokemon.keys())
         pokemon_ids.update(self._active_pokemon.keys())

--- a/src/poke_env/battle/double_battle.py
+++ b/src/poke_env/battle/double_battle.py
@@ -39,6 +39,8 @@ class DoubleBattle(AbstractBattle):
     OPPONENT_1_POSITION = 1
     OPPONENT_2_POSITION = 2
     EMPTY_TARGET_POSITION = 0  # symbolic, not used by showdown
+    ALLY_POSITIONS = {"a": POKEMON_1_POSITION, "b": POKEMON_2_POSITION}
+    FOE_POSITIONS = {"a": OPPONENT_1_POSITION, "b": OPPONENT_2_POSITION}
 
     def __init__(
         self,
@@ -380,18 +382,11 @@ class DoubleBattle(AbstractBattle):
                 slots = _SHOWDOWN_TARGET_SLOTS[move.deduced_target.name]
                 targets = [slot_map[s] for s in slots]
 
-        pokemon_ids = set(self._opponent_active_pokemon.keys())
-        pokemon_ids.update(self._active_pokemon.keys())
-        targets_to_keep = {
-            {
-                f"{self.player_role}a": -1,
-                f"{self.player_role}b": -2,
-                f"{self.opponent_role}a": 1,
-                f"{self.opponent_role}b": 2,
-            }[pokemon_identifier]
-            for pokemon_identifier in pokemon_ids
-        }
-        targets_to_keep.add(self.EMPTY_TARGET_POSITION)
+        targets_to_keep = (
+            {self.EMPTY_TARGET_POSITION}
+            | {self.ALLY_POSITIONS[pid[2]] for pid in self._active_pokemon}
+            | {self.FOE_POSITIONS[pid[2]] for pid in self._opponent_active_pokemon}
+        )
         targets = [target for target in targets if target in targets_to_keep]
 
         return targets

--- a/src/poke_env/battle/double_battle.py
+++ b/src/poke_env/battle/double_battle.py
@@ -376,11 +376,8 @@ class DoubleBattle(AbstractBattle):
                 "opp2": self.OPPONENT_2_POSITION,
                 "empty": self.EMPTY_TARGET_POSITION,
             }
-            if move.deduced_target is None:
-                targets = [self.OPPONENT_1_POSITION, self.OPPONENT_2_POSITION]
-            else:
-                slots = _SHOWDOWN_TARGET_SLOTS[move.deduced_target.name]
-                targets = [slot_map[s] for s in slots]
+            slots = _SHOWDOWN_TARGET_SLOTS[move.deduced_target.name]
+            targets = [slot_map[s] for s in slots]
 
         targets_to_keep = (
             {self.EMPTY_TARGET_POSITION}

--- a/src/poke_env/battle/move.py
+++ b/src/poke_env/battle/move.py
@@ -245,7 +245,7 @@ class Move:
         return self.entry.get("damage", 0)
 
     @property
-    def deduced_target(self) -> Optional[Target]:
+    def deduced_target(self) -> Target:
         """
         :return: Move deduced target, based on Move.target and showdown's request
             messages.
@@ -255,9 +255,8 @@ class Move:
             return self.target
         elif self.request_target:
             return self.request_target
-        elif self.target == "randomNormal":
-            return self.request_target
-        return self.target
+        else:
+            return self.target
 
     @property
     def defensive_category(self) -> MoveCategory:
@@ -670,14 +669,12 @@ class Move:
         return self.entry.get("stealsBoosts", False)
 
     @property
-    def target(self) -> Optional[Target]:
+    def target(self) -> Target:
         """
         :return: Target of the move
         :rtype: Optional[Target]
         """
-        if "target" in self.entry:
-            return Target.from_showdown_message(self.entry["target"])
-        return None
+        return Target.from_showdown_message(self.entry["target"])
 
     @property
     def terrain(self) -> Optional[Field]:

--- a/src/poke_env/player/battle_order.py
+++ b/src/poke_env/player/battle_order.py
@@ -95,8 +95,7 @@ class DoubleBattleOrder(BattleOrder):
             if not (first_order.terastallize and second_order.terastallize)
             if not (
                 isinstance(first_order.order, Pokemon)
-                and isinstance(second_order.order, Pokemon)
-                and str(first_order) == str(second_order)
+                and first_order.order is second_order.order
             )
             if not (
                 isinstance(first_order, PassBattleOrder)


### PR DESCRIPTION
Addresses #902 and #903

I think the most not-just-a-refactor change in this changeset is changing

```
        if pokemon == pokemon_1 and move.id in [m.id for m in self.available_moves[0]]:
            self_position = self.POKEMON_1_POSITION
            ally_position = self.POKEMON_2_POSITION
        elif pokemon == pokemon_2 and move.id in [
            m.id for m in self.available_moves[1]
        ]:
```

to

```
        if pokemon is pokemon_1:
            self_position = self.POKEMON_1_POSITION
            ally_position = self.POKEMON_2_POSITION
        elif pokemon is pokemon_2:
```

because it gets rid of the check to see if the move is in the pokemon's moveset. I actually don't think that is a necessary check though. It is a valid thing to ask "*if* this pokemon had this move, what would the possible targets be?", and thus, I think this change is acceptable.