### PR TITLE
Revert #883

### DIFF
--- a/src/poke_env/battle/abstract_battle.py
+++ b/src/poke_env/battle/abstract_battle.py
@@ -13,7 +13,6 @@ from poke_env.battle.side_condition import STACKABLE_CONDITIONS, SideCondition
 from poke_env.battle.weather import Weather
 from poke_env.data import GenData, to_id_str
 from poke_env.data.replay_template import REPLAY_TEMPLATE
-from poke_env.teambuilder.teambuilder_pokemon import TeambuilderPokemon
 
 
 class AbstractBattle(ABC):
@@ -110,7 +109,6 @@ class AbstractBattle(ABC):
         "_side_conditions",
         "_team_size",
         "_team",
-        "_teambuilder_team",
         "_teampreview_team",
         "_teampreview_opponent_team",
         "_teampreview",
@@ -186,7 +184,6 @@ class AbstractBattle(ABC):
 
         # Pokemon attributes
         self._team: Dict[str, Pokemon] = {}
-        self._teambuilder_team: list[TeambuilderPokemon] | None = None
         self._opponent_team: Dict[str, Pokemon] = {}
 
     def get_pokemon(
@@ -1259,23 +1256,6 @@ class AbstractBattle(ABC):
             self._replay_data.append(["", "tie"])
         self._finish_battle()
 
-    def apply_teambuilder_team(
-        self,
-        role: str,
-        teambuilder_team: List[TeambuilderPokemon],
-        teampreview_team: List[Pokemon],
-    ):
-        for preview_mon in teampreview_team:
-            teambuilder_mon = [
-                m
-                for m in teambuilder_team
-                if m.nickname is not None and preview_mon.identifies_as(m.nickname)
-            ][0]
-            mon = self.get_pokemon(
-                f"{role}: {teambuilder_mon.nickname}", details=preview_mon._last_details
-            )
-            mon._update_from_teambuilder(teambuilder_mon)
-
     def _update_team_from_request(
         self, side: Dict[str, Any], strict_battle_tracking: bool = False
     ):
@@ -1684,10 +1664,6 @@ class AbstractBattle(ABC):
         raise ValueError(
             "Team size cannot be inferred without an assigned player role."
         )
-
-    @property
-    def teambuilder_team(self) -> list[TeambuilderPokemon] | None:
-        return self._teambuilder_team
 
     @property
     def teampreview(self) -> bool:

--- a/src/poke_env/battle/battle.py
+++ b/src/poke_env/battle/battle.py
@@ -100,11 +100,6 @@ class Battle(AbstractBattle):
 
         if side["pokemon"]:
             self._player_role = side["pokemon"][0]["ident"][:2]
-        if self.teambuilder_team is not None and not self.team:
-            assert self.player_role is not None
-            self.apply_teambuilder_team(
-                self.player_role, self.teambuilder_team, self.teampreview_team
-            )
         self._update_team_from_request(side, strict_battle_tracking)
 
         if "active" in request:

--- a/src/poke_env/battle/double_battle.py
+++ b/src/poke_env/battle/double_battle.py
@@ -162,11 +162,6 @@ class DoubleBattle(AbstractBattle):
         side = request["side"]
         if side["pokemon"]:
             self._player_role = side["pokemon"][0]["ident"][:2]
-        if self.teambuilder_team is not None and not self.team:
-            assert self.player_role is not None
-            self.apply_teambuilder_team(
-                self.player_role, self.teambuilder_team, self.teampreview_team
-            )
         self._update_team_from_request(side, strict_battle_tracking)
 
         if "active" in request:

--- a/src/poke_env/battle/pokemon.py
+++ b/src/poke_env/battle/pokemon.py
@@ -769,10 +769,10 @@ class Pokemon:
             move = Move(Move.retrieve_id(move_str), gen=self.gen)
             self._moves[move.id] = move
 
-        if not all(e == 0 for e in tb.evs):
+        if tb.nature is not None:
             self._evs = tb.evs
             self._ivs = tb.ivs
-            self._nature = tb.nature.lower() if tb.nature is not None else "serious"
+            self._nature = tb.nature
 
         if tb.level:
             nature = tb.nature.lower() if tb.nature else "serious"

--- a/src/poke_env/player/player.py
+++ b/src/poke_env/player/player.py
@@ -139,7 +139,6 @@ class Player(ABC):
         self._waiting: Event = create_in_poke_loop(Event, loop)
         self._trying_again: Event = create_in_poke_loop(Event, loop)
         self._team: Optional[Teambuilder] = None
-        self._current_packed_team: str | None = None
         self._strict_battle_tracking = strict_battle_tracking
 
         if isinstance(team, Teambuilder):
@@ -213,10 +212,12 @@ class Player(ABC):
                         save_replays=self._save_replays,
                     )
 
-                if self._current_packed_team:
-                    battle._teambuilder_team = Teambuilder.parse_packed_team(
-                        self._current_packed_team
-                    )
+                # Add our team as teampreview_team, as part of battle initialisation
+                if isinstance(self._team, ConstantTeambuilder):
+                    battle.teampreview_team = [
+                        Pokemon(gen=gen, teambuilder=tb_mon)
+                        for tb_mon in self._team.team
+                    ]
 
                 await self._battle_count_queue.put(None)
                 if battle_tag in self._battles:
@@ -294,15 +295,29 @@ class Player(ABC):
                         await self._handle_battle_request(battle)
             elif split_message[1] == "showteam":
                 role = split_message[2]
-                if role == battle.player_role:
-                    continue
                 teambuilder_team = Teambuilder.parse_packed_team(
                     "|".join(split_message[3:])
                 )
-                battle.apply_teambuilder_team(
-                    role, teambuilder_team, battle.teampreview_opponent_team
+                teampreview_team = (
+                    battle.teampreview_team
+                    if role == battle.player_role
+                    else battle.teampreview_opponent_team
                 )
-                await self._handle_battle_request(battle)
+                for preview_mon in teampreview_team:
+                    teambuilder_mon = [
+                        m
+                        for m in teambuilder_team
+                        if m.nickname is not None
+                        and preview_mon.identifies_as(m.nickname)
+                    ][0]
+                    mon = battle.get_pokemon(
+                        f"{role}: {teambuilder_mon.nickname}",
+                        details=preview_mon._last_details,
+                    )
+                    mon._update_from_teambuilder(teambuilder_mon)
+                # only handle battle request after all open sheets are processed
+                if role == "p2":
+                    await self._handle_battle_request(battle)
             elif split_message[1] == "win" or split_message[1] == "tie":
                 if split_message[1] == "win":
                     battle.won_by(split_message[2])
@@ -420,10 +435,7 @@ class Player(ABC):
         self.logger.debug("Event logged in received in accept_challenge")
 
         for _ in range(n_challenges):
-            if packed_team:
-                self._current_packed_team = packed_team
-            else:
-                self.get_next_team()
+            team = packed_team or self.next_team
             while True:
                 username = to_id_str(await self._challenge_queue.get())
                 self.logger.debug(
@@ -434,9 +446,7 @@ class Player(ABC):
                     or (opponent == username)
                     or (isinstance(opponent, list) and (username in opponent))
                 ):
-                    await self.ps_client.accept_challenge(
-                        username, self._current_packed_team
-                    )
+                    await self.ps_client.accept_challenge(username, team)
                     await self._battle_semaphore.acquire()
                     break
         await self._battle_count_queue.join()
@@ -513,9 +523,7 @@ class Player(ABC):
 
         for _ in range(n_games):
             async with self._battle_start_condition:
-                await self.ps_client.search_ladder_game(
-                    self._format, self.get_next_team()
-                )
+                await self.ps_client.search_ladder_game(self._format, self.next_team)
                 await self._battle_start_condition.wait()
                 while self._battle_count_queue.full():
                     async with self._battle_end_condition:
@@ -588,7 +596,7 @@ class Player(ABC):
         start_time = perf_counter()
 
         for _ in range(n_challenges):
-            await self.ps_client.challenge(opponent, self._format, self.get_next_team())
+            await self.ps_client.challenge(opponent, self._format, self.next_team)
             await self._battle_semaphore.acquire()
         await self._battle_count_queue.join()
         self.logger.info(
@@ -702,12 +710,6 @@ class Player(ABC):
             )
         return battle.save_replay(file_path)
 
-    def get_next_team(self) -> str | None:
-        if self._team:
-            self._current_packed_team = self._team.yield_team()
-            return self._current_packed_team
-        return None
-
     @property
     def battles(self) -> Dict[str, AbstractBattle]:
         return self._battles
@@ -756,3 +758,9 @@ class Player(ABC):
     @property
     def username(self) -> str:
         return self.ps_client.username
+
+    @property
+    def next_team(self) -> Optional[str]:
+        if self._team:
+            return self._team.yield_team()
+        return None

--- a/unit_tests/environment/test_battle.py
+++ b/unit_tests/environment/test_battle.py
@@ -9,14 +9,12 @@ from poke_env.battle import (
     Battle,
     Effect,
     Field,
-    Pokemon,
     PokemonType,
     SideCondition,
     Status,
     Weather,
 )
 from poke_env.data import GenData
-from poke_env.teambuilder import Teambuilder
 
 
 def _extract_replay_log_lines(replay_html: str):
@@ -192,10 +190,6 @@ def test_battle_request_parsing(example_request):
         "spd": 211,
         "spe": 178,
     }
-    # No teambuilder data set, so nature/EVs/IVs should be None
-    assert mon.nature is None
-    assert mon._evs is None
-    assert mon._ivs is None
 
     moves = mon.moves
     assert (
@@ -223,25 +217,6 @@ def test_battle_request_parsing(example_request):
     assert len(battle.available_moves) == 4
 
     assert team["p2: Necrozma"].status == Status.TOX
-
-
-def test_battle_request_applies_teambuilder_data(example_request):
-    logger = MagicMock()
-    battle = Battle("tag", "username", logger, gen=8)
-
-    battle._teambuilder_team = Teambuilder.parse_packed_team(
-        "Venusaur||blacksludge|chlorophyll|leechseed,sleeppowder,substitute,sludgebomb"
-        "|Calm|252,,4,,252,|M|,,,,,||82|"
-    )
-    battle.teampreview_team = [Pokemon(details="Venusaur, L82, M", gen=8)]
-
-    battle.parse_request(example_request)
-
-    mon = battle.active_pokemon
-    assert mon.species == "venusaur"
-    assert mon.nature == "calm"
-    assert mon._evs == [252, 0, 4, 0, 252, 0]
-    assert mon._ivs == [31, 31, 31, 31, 31, 31]
 
 
 def test_battle_request_parsing_with_force_switch(force_switch_example_request):

--- a/unit_tests/player/test_player_misc.py
+++ b/unit_tests/player/test_player_misc.py
@@ -3,7 +3,14 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from poke_env import AccountConfiguration
-from poke_env.battle import AbstractBattle, Battle, DoubleBattle, Move
+from poke_env.battle import (
+    AbstractBattle,
+    Battle,
+    DoubleBattle,
+    Move,
+    PokemonGender,
+    PokemonType,
+)
 from poke_env.player import (
     BattleOrder,
     Player,
@@ -11,6 +18,7 @@ from poke_env.player import (
     SingleBattleOrder,
     cross_evaluate,
 )
+from poke_env.stats import _raw_hp, _raw_stat
 
 
 class SimplePlayer(Player):
@@ -257,49 +265,52 @@ async def test_handle_battle_request_waits_when_battle_waiting(send_message_patc
 
 
 @pytest.mark.asyncio
-async def test_create_teambuilder_team(showdown_format_teams):
+async def test_create_teampreview_team(showdown_format_teams):
     player = SimplePlayer(
         battle_format="gen9vgc2024regg",
         team=showdown_format_teams["gen9vgc2024regg"][0],
     )
 
-    player.get_next_team()
     battle = await player._create_battle(["", "gen9vgc2024regg", "uuu"])
 
-    assert battle.teambuilder_team is not None
-    assert len(battle.teambuilder_team) == 6
+    assert len(battle.teampreview_team) == 6
 
-    tb_mon = None
-    for m in battle.teambuilder_team:
-        if m.nickname == "Iron Hands":
-            tb_mon = m
+    mon = None
+    for teampreview_mon in battle.teampreview_team:
+        if teampreview_mon.species == "ironhands":
+            mon = teampreview_mon
 
-    assert tb_mon
-    assert tb_mon.nickname == "Iron Hands"
-    assert tb_mon.level == 50
-    assert tb_mon.ability == "quarkdrive"
-    assert tb_mon.item == "assaultvest"
-    assert tb_mon.moves == ["fakeout", "drainpunch", "wildcharge", "heavyslam"]
-    assert tb_mon.tera_type == "Water"
-    assert tb_mon.nature == "Adamant"
-    assert tb_mon.evs == [4, 156, 4, 0, 252, 92]
-    assert tb_mon.ivs == [31, 31, 31, 31, 31, 31]
+    assert mon
+    assert mon.name == "Iron Hands"
+    assert mon.level == 50
+    assert mon.ability == "quarkdrive"
+    assert mon.item == "assaultvest"
+    assert list(mon.moves.keys()) == [
+        "fakeout",
+        "drainpunch",
+        "wildcharge",
+        "heavyslam",
+    ]
+    assert mon.tera_type == PokemonType.WATER
+    assert mon.stats["hp"] == _raw_hp(mon.base_stats["hp"], 4, 31, 50)
+    assert mon.stats["atk"] == _raw_stat(mon.base_stats["atk"], 156, 31, 50, 1.1)
+
+    assert any(map(lambda x: x.species == "fluttermane", battle.teampreview_team))
 
 
 @pytest.mark.asyncio
-async def test_create_teambuilder_team_handles_neutral_gender_from_packed():
+async def test_create_teampreview_team_handles_neutral_gender_from_packed():
     player = SimplePlayer(
         battle_format="gen3ubers",
         team="Starmie|||naturalcure|surf,icebeam,thunderbolt,rapidspin|Timid|"
         "4,,,252,,252|N|||100|",
     )
 
-    player.get_next_team()
     battle = await player._create_battle(["", "gen3ubers", "uuu"])
 
-    assert len(battle.teambuilder_team) == 1
-    assert battle.teambuilder_team[0].nickname == "Starmie"
-    assert battle.teambuilder_team[0].gender == "N"
+    assert len(battle.teampreview_team) == 1
+    assert battle.teampreview_team[0].species == "starmie"
+    assert battle.teampreview_team[0].gender == PokemonGender.NEUTRAL
 
 
 @pytest.mark.asyncio
@@ -318,13 +329,12 @@ async def test_parse_showteam(packed_format_teams):
     )
     assert len(battle.teampreview_opponent_team) == 1
 
-    with patch.object(player.ps_client, "send_message", new_callable=AsyncMock):
-        await player._handle_battle_message(
-            [
-                [f">{battle.battle_tag}"],
-                ["", "showteam", battle.opponent_role, *packed_team.split("|")],
-            ]
-        )
+    await player._handle_battle_message(
+        [
+            [f">{battle.battle_tag}"],
+            ["", "showteam", battle.opponent_role, *packed_team.split("|")],
+        ]
+    )
     assert "p1: Iron Hands" in battle.opponent_team
 
     mon = battle.get_pokemon("p1: donut", details="Iron Hands, L50")


### PR DESCRIPTION
This feature is making it really hard to implement #898 due to race conditions that this can cause. Undoing this doesn't really lose much, since the user still has access to the true stats of their own team from the request message. The reason I want to get rid of this is that the _teambuilder_team field tracking is vulnerable to race conditions when running bo3 games concurrently.

I think the better implementation of what this was trying to do would be to change PS and make it so the `showteam` message carries the ev's, iv's, and natures, which I'm not exactly sure why it doesn't right now.