### PR TITLE
Refine strict battle tracking

### DIFF
--- a/src/poke_env/battle/abstract_battle.py
+++ b/src/poke_env/battle/abstract_battle.py
@@ -992,7 +992,13 @@ class AbstractBattle(ABC):
                     "[from] move: Switcheroo",
                     "[from] move: Trick",
                 ]:
-                    # this event is handled when consuming -activate event
+                    # The swap was already applied in the preceding -activate
+                    # event, but if our local state still says the item is
+                    # unknown (e.g. we never observed the opponent's item),
+                    # use the authoritative value from this event.
+                    mon = self.get_pokemon(pokemon)
+                    if mon.item == "unknown_item":
+                        mon.item = to_id_str(item)
                     return
                 self.get_pokemon(pokemon).item = to_id_str(item)
         elif event[1] == "-mega":
@@ -1285,9 +1291,7 @@ class AbstractBattle(ABC):
 
         for pokemon in side["pokemon"]:
             if pokemon["ident"] in self._team:
-                if strict_battle_tracking and "illusion" not in [
-                    p.ability for p in self.team.values()
-                ]:
+                if strict_battle_tracking and self.turn > 1:
                     assert self.player_role is not None
                     self._team[pokemon["ident"]].check_consistency(
                         pokemon, self.player_role

--- a/src/poke_env/battle/pokemon.py
+++ b/src/poke_env/battle/pokemon.py
@@ -226,10 +226,6 @@ class Pokemon:
             pkmn_request["active"] == self.active
         ), f"{pkmn_request['active']} != {self.active}"
         if self.gen >= 2:
-            if self.item == "unknown_item":
-                # needed for item initialization in start of game,
-                # done anyway in update_from_request()
-                self._item = pkmn_request["item"]
             assert pkmn_request["item"] == (
                 self.item or ""
             ), f"{pkmn_request['item']} != {self.item or ''}"
@@ -239,21 +235,10 @@ class Pokemon:
         assert (
             pkmn_request["condition"] == self.hp_status
         ), f"{pkmn_request['condition']} != {self.hp_status}"
-        if self.ability is None:
-            # needed for ability initialization in start of game,
-            # done anyway in update_from_request()
-            self.ability = pkmn_request["baseAbility"]
         assert pkmn_request["baseAbility"] == (
             self.base_ability or ""
         ), f"{pkmn_request['baseAbility']} != {self.base_ability or ''}"
         if "ability" in pkmn_request:
-            if (
-                pkmn_request["baseAbility"] != pkmn_request["ability"]
-                and self._temporary_ability is None
-            ):
-                # needed for ability initialization in start of game,
-                # done anyway in update_from_request()
-                self._temporary_ability = to_id_str(pkmn_request["ability"])
             assert pkmn_request["ability"] == (
                 self.ability or ""
             ), f"{pkmn_request['ability']} != {self.ability or ''}"


### PR DESCRIPTION
Strict battle tracking is now a bit more realistic. We now allow a single request ingestion at the beginning of the battle to fill in the pokemon's items and abilities, and that way we can remove those exception fill-ins in the check_consistency method. This revealed a bad handling of unknown_item during an item swap, which has now been fixed.