### PR TITLE
Fix Showdown integration compatibility

### DIFF
--- a/integration_tests/test_double_battles.py
+++ b/integration_tests/test_double_battles.py
@@ -31,7 +31,7 @@ async def simple_cross_evaluation(n_battles, format_, i=0):
 
 
 @pytest.mark.asyncio
-async def test_small_cross_evaluation_gen8():
+async def test_small_cross_evaluation_gen9():
     await asyncio.wait_for(
-        simple_cross_evaluation(5, format_="gen8randomdoublesbattle", i=3), timeout=20
+        simple_cross_evaluation(5, format_="gen9randomdoublesbattle", i=3), timeout=20
     )

--- a/integration_tests/test_doubles_env.py
+++ b/integration_tests/test_doubles_env.py
@@ -43,7 +43,7 @@ def play_function(env, n_battles):
 
 @pytest.mark.timeout(120)
 def test_env_run():
-    for gen in range(8, 10):
+    for gen in (9,):
         env = DoublesTestEnv(battle_format=f"gen{gen}randomdoublesbattle", log_level=25)
         play_function(env, 10)
         env._strict = False
@@ -67,7 +67,7 @@ def single_agent_play_function(env: SingleAgentWrapper, n_battles: int):
 
 @pytest.mark.timeout(120)
 def test_single_agent_env_run():
-    for gen in range(8, 10):
+    for gen in (9,):
         env = DoublesTestEnv(battle_format=f"gen{gen}randomdoublesbattle", log_level=25)
         env = SingleAgentWrapper(env, RandomPlayer())
         single_agent_play_function(env, 10)
@@ -101,12 +101,6 @@ def sample_action(action_mask):
 @pytest.mark.timeout(60)
 def test_repeated_runs():
     env = DoublesTestEnv(
-        battle_format="gen8randomdoublesbattle", log_level=25, strict=False
-    )
-    play_function(env, 2)
-    play_function(env, 2)
-    env.close()
-    env = DoublesTestEnv(
         battle_format="gen9randomdoublesbattle", log_level=25, strict=False
     )
     play_function(env, 2)
@@ -116,7 +110,7 @@ def test_repeated_runs():
 
 @pytest.mark.timeout(60)
 def test_single_agent_env_api():
-    for gen in range(8, 10):
+    for gen in (9,):
         env = DoublesTestEnv(
             battle_format=f"gen{gen}randomdoublesbattle", log_level=25, strict=False
         )

--- a/src/poke_env/battle/pokemon.py
+++ b/src/poke_env/battle/pokemon.py
@@ -53,6 +53,7 @@ class Pokemon:
         "_selected_in_teampreview",
         "_temporary_ability",
         "_temporary_base_stats",
+        "_temporary_move",
         "_temporary_types",
         "_terastallized",
         "_terastallized_type",
@@ -133,6 +134,7 @@ class Pokemon:
         self._temporary_ability: Optional[str] = None
         self._forme_change_ability: Optional[str] = None
         self._temporary_base_stats: Optional[Dict[str, int]] = None
+        self._temporary_move: Optional[Move] = None
         self._temporary_types: List[PokemonType] = []
         self._dancing = False
 
@@ -451,13 +453,34 @@ class Pokemon:
         self._preparing_move = None
         self._preparing_target = None
         move = None
+        self._temporary_move = None
         if reveal:
-            move = self._add_move(move_id)
+            id_ = Move.retrieve_id(move_id)
+            requested_moves = {
+                Move.retrieve_id(requested_move)
+                for requested_move in (self._last_request or {}).get("moves", [])
+            }
+            if (
+                self.gen == 1
+                and requested_moves
+                and id_ not in requested_moves
+                and Move.should_be_stored(id_, self.gen)
+            ):
+                # Gen 1's Desync Clause Mod can make a thawed Pokemon use the
+                # last move selected by its team, even if it does not know that
+                # move. Keep the observed move available as last_move without
+                # polluting the Pokemon's actual move set.
+                move = Move(move_id=id_, raw_id=move_id, gen=self.gen)
+                self._temporary_move = move
+            else:
+                move = self._add_move(move_id)
         if use:
             if move is not None:
                 move.use(pressure)
             for m in self.moves.values():
                 m._is_last_used = m is move
+            if self._temporary_move is not None:
+                self._temporary_move._is_last_used = True
 
         if move is not None and move.is_protect_counter and not failed:
             self._protect_counter += 1
@@ -597,6 +620,7 @@ class Pokemon:
         self._protect_counter = 0
         self.temporary_ability = None
         self._temporary_base_stats = None
+        self._temporary_move = None
         self._moves._transform_moves = None
         self._moves.mimic_move = None
         self._temporary_types = []
@@ -1115,7 +1139,9 @@ class Pokemon:
         :return: The last move used by this pokemon, or None.
         :rtype: Move | None
         """
-        for move in self.moves.values():
+        for move in [self._temporary_move, *self.moves.values()]:
+            if move is None:
+                continue
             if move.is_last_used:
                 return move
         return None

--- a/strict_integration_tests/test_strict.py
+++ b/strict_integration_tests/test_strict.py
@@ -42,7 +42,7 @@ async def test_random_players():
 
 @pytest.mark.asyncio
 async def test_random_double_players():
-    for gen in range(8, 10):
+    for gen in (9,):
         players = [
             ZoroarkForfeitRandomPlayer(
                 battle_format=f"gen{gen}randomdoublesbattle",

--- a/unit_tests/environment/test_pokemon.py
+++ b/unit_tests/environment/test_pokemon.py
@@ -29,6 +29,29 @@ def test_pokemon_moves():
     assert not mon.must_recharge
 
 
+def test_gen1_unowned_move_is_temporary():
+    request = {
+        "active": True,
+        "baseAbility": "noability",
+        "condition": "319/319",
+        "details": "Slowpoke, L83",
+        "ident": "p1: Slowpoke",
+        "item": "",
+        "moves": ["blizzard", "psychic", "amnesia", "thunderwave"],
+    }
+    mon = Pokemon(1, request_pokemon=request)
+
+    mon.moved("fireblast")
+
+    assert set(mon.moves) == {"blizzard", "psychic", "amnesia", "thunderwave"}
+    assert mon.last_move is not None
+    assert mon.last_move.id == "fireblast"
+    mon.check_consistency(request, "p1")
+
+    mon.moved("psychic")
+    assert mon.last_move == mon.moves["psychic"]
+
+
 def test_pokemon_types():
     # single type
     mon = Pokemon(species="pikachu", gen=8)


### PR DESCRIPTION
## Summary

- replace removed `gen8randomdoublesbattle` integration coverage with the supported Gen 9 format
- keep Gen 1 Desync Clause moves transient when the player's request proves the Pokémon does not own the observed move
- add a regression test covering a Slowpoke temporarily using a teammate's Fire Blast without gaining a fifth move

## Root cause

Pokémon Showdown removed Gen 8 Random Doubles, so integration tests timed out after the local server rejected the format.

A later Showdown update implemented Gen 1 Desync Clause behavior where a thawed Pokémon can use the last move selected by its team even when that move is not in its own moveset. poke-env treated that observed move as owned, causing strict tracking to fail its four-move invariant.

## Impact

This restores the currently failing Dependabot and nightly integration paths while preserving strict move tracking. The borrowed Gen 1 move remains available through `last_move` but is not added to the Pokémon's canonical `moves`.

## Verification

- `uv run --no-sync pytest -q unit_tests/ -x` — 281 passed
- Black, Flake8, isort, and mypy — passed
- updated Gen 9 integration and strict doubles tests against current Pokémon Showdown — 6 passed
- strict Gen 1–9 random-player nightly reproduction against current Pokémon Showdown — passed