### PR TITLE
Expand Smogon usage stats

### DIFF
--- a/docs/source/modules/data.rst
+++ b/docs/source/modules/data.rst
@@ -16,9 +16,9 @@ and cached in ``.poke_env_stats_cache`` by default.
    great_tusk = stats["Great Tusk"]
    counters = great_tusk.top_counters(limit=5, min_weighted_encounters=100)
 
-Pass ``cache_dir=None`` to disable caching, ``refresh=True`` to replace a cached
-snapshot, or ``compressed=False`` to request uncompressed JSON. When an older
-snapshot has no compressed resource, fetching falls back to its uncompressed JSON.
+Pass ``cache_dir=None`` to disable caching or ``refresh=True`` to replace a cached
+snapshot. When an older snapshot has no compressed resource, fetching falls back to
+its uncompressed JSON and stores it in the compressed cache format.
 
 .. automodule:: poke_env.data.gen_data
    :members:

--- a/docs/source/modules/data.rst
+++ b/docs/source/modules/data.rst
@@ -1,12 +1,36 @@
 Data: Access and manipulate comprehensive Pokémon data
 ======================================================
 
+Smogon usage statistics
+-----------------------
+
+``SmogonStats`` loads a reproducible, cutoff-specific monthly snapshot of
+Smogon's usage statistics. Remote snapshots are downloaded as compressed JSON
+and cached in ``.poke_env_stats_cache`` by default.
+
+.. code-block:: python
+
+   from poke_env.data import SmogonStats
+
+   stats = SmogonStats.fetch("gen9ou", month="2026-07", cutoff=1695)
+   great_tusk = stats["Great Tusk"]
+   counters = great_tusk.top_counters(limit=5, min_weighted_encounters=100)
+
+Pass ``cache_dir=None`` to disable caching, ``refresh=True`` to replace a cached
+snapshot, or ``compressed=False`` to request uncompressed JSON. When an older
+snapshot has no compressed resource, fetching falls back to its uncompressed JSON.
+
 .. automodule:: poke_env.data.gen_data
    :members:
    :undoc-members:
    :show-inheritance:
 
 .. automodule:: poke_env.data.normalize
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: poke_env.data.smogon
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/source/modules/data.rst
+++ b/docs/source/modules/data.rst
@@ -4,21 +4,23 @@ Data: Access and manipulate comprehensive Pokémon data
 Smogon usage statistics
 -----------------------
 
-``SmogonStats`` loads a reproducible, cutoff-specific monthly snapshot of
-Smogon's usage statistics. Remote snapshots are downloaded as compressed JSON
-and cached in ``.poke_env_stats_cache`` by default.
+``SmogonStats`` loads a cutoff-specific monthly snapshot of Smogon's usage
+statistics. Remote snapshots are downloaded as compressed JSON and cached in
+``.poke_env_stats_cache`` by default.
 
 .. code-block:: python
 
    from poke_env.data import SmogonStats
 
-   stats = SmogonStats.fetch("gen9ou", month="2026-07", cutoff=1695)
+   stats = SmogonStats.fetch("gen9ou", cutoff=1695)
    great_tusk = stats["Great Tusk"]
    counters = great_tusk.top_counters(limit=5, min_weighted_encounters=100)
 
 Pass ``cache_dir=None`` to disable caching or ``refresh=True`` to replace a cached
 snapshot. When an older snapshot has no compressed resource, fetching falls back to
 its uncompressed JSON and stores it in the compressed cache format.
+The ``month`` parameter defaults to the latest month listed by Smogon; pass an
+explicit ``YYYY-MM`` month when reproducibility is required.
 
 .. automodule:: poke_env.data.gen_data
    :members:

--- a/src/poke_env/data/__init__.py
+++ b/src/poke_env/data/__init__.py
@@ -1,5 +1,25 @@
 from poke_env.data.gen_data import GenData
 from poke_env.data.normalize import to_id_str
 from poke_env.data.replay_template import REPLAY_TEMPLATE
+from poke_env.data.smogon import (
+    CounterStats,
+    PokemonUsageStats,
+    SmogonStats,
+    SmogonStatsError,
+    SmogonStatsNotFoundError,
+    SmogonStatsParseError,
+    Spread,
+)
 
-__all__ = ["REPLAY_TEMPLATE", "GenData", "to_id_str"]
+__all__ = [
+    "CounterStats",
+    "GenData",
+    "PokemonUsageStats",
+    "REPLAY_TEMPLATE",
+    "SmogonStats",
+    "SmogonStatsError",
+    "SmogonStatsNotFoundError",
+    "SmogonStatsParseError",
+    "Spread",
+    "to_id_str",
+]

--- a/src/poke_env/data/smogon.py
+++ b/src/poke_env/data/smogon.py
@@ -1,9 +1,11 @@
 """Access to Smogon's monthly Pokemon Showdown usage statistics."""
 
+import gzip
 import re
 from dataclasses import dataclass
 from math import isfinite
 from pathlib import Path
+from tempfile import NamedTemporaryFile
 from types import MappingProxyType
 from typing import Any, Mapping, Optional, Union
 
@@ -14,6 +16,7 @@ from poke_env.data.normalize import to_id_str
 
 JsonPayload = Union[str, bytes, bytearray, memoryview]
 _MONTH_PATTERN = re.compile(r"^[0-9]{4}-(0[1-9]|1[0-2])$")
+_DEFAULT_CACHE_DIR = Path(".poke_env_stats_cache")
 
 
 class SmogonStatsError(Exception):
@@ -41,6 +44,28 @@ class Spread:
 
 
 @dataclass(frozen=True, slots=True)
+class CounterStats:
+    """Smogon's checks-and-counters statistics for one opposing Pokemon.
+
+    ``knockout_or_switch_probability`` is the probability that the subject Pokemon
+    was knocked out by, or switched out against, this opposing Pokemon during a
+    relevant encounter. ``standard_error`` measures the uncertainty in that
+    probability.
+    """
+
+    id: str
+    name: str
+    weighted_encounters: float
+    knockout_or_switch_probability: float
+    standard_error: float
+
+    @property
+    def score(self) -> float:
+        """Return Smogon's conservative checks-and-counters ranking score."""
+        return self.knockout_or_switch_probability - 4 * self.standard_error
+
+
+@dataclass(frozen=True, slots=True)
 class PokemonUsageStats:
     """Usage statistics for one Pokemon in a Smogon snapshot.
 
@@ -61,6 +86,24 @@ class PokemonUsageStats:
     spreads: Mapping[Spread, float]
     tera_types: Mapping[str, float]
     teammate_scores: Mapping[str, float]
+    checks_and_counters: Mapping[str, CounterStats]
+
+    def top_counters(
+        self, limit: Optional[int] = None, *, min_weighted_encounters: float = 0
+    ) -> tuple[CounterStats, ...]:
+        """Return checks and counters ordered by Smogon's conservative score."""
+        _validate_limit(limit)
+        _validate_finite_number(min_weighted_encounters, "min_weighted_encounters")
+        if min_weighted_encounters < 0:
+            raise ValueError("min_weighted_encounters must not be negative")
+
+        matches = (
+            counter
+            for counter in self.checks_and_counters.values()
+            if counter.weighted_encounters >= min_weighted_encounters
+        )
+        ordered = sorted(matches, key=lambda counter: (-counter.score, counter.id))
+        return tuple(ordered[:limit])
 
 
 @dataclass(frozen=True, slots=True)
@@ -76,12 +119,27 @@ class SmogonStats:
 
     @classmethod
     def fetch(
-        cls, battle_format: str, *, month: str, cutoff: int = 0, timeout: float = 30
+        cls,
+        battle_format: str,
+        *,
+        month: str,
+        cutoff: int = 0,
+        timeout: float = 30,
+        cache_dir: Optional[Union[str, Path]] = _DEFAULT_CACHE_DIR,
+        refresh: bool = False,
+        compressed: bool = True,
     ) -> "SmogonStats":
         """Fetch and parse a snapshot from Smogon's public chaos directory.
 
         ``month`` is deliberately explicit so experiments remain reproducible.
         The default ``cutoff=0`` selects Smogon's unweighted statistics.
+
+        Downloads use Smogon's gzip-compressed snapshots by default and are cached
+        under ``.poke_env_stats_cache`` in the current directory. Pass
+        ``cache_dir=None`` to disable caching, ``refresh=True`` to replace a cached
+        snapshot, or ``compressed=False`` to request uncompressed JSON. If a
+        compressed snapshot is unavailable, fetching falls back to uncompressed
+        JSON.
         """
         normalized_format = to_id_str(battle_format)
         if not normalized_format:
@@ -91,13 +149,28 @@ class SmogonStats:
         if timeout <= 0:
             raise ValueError("timeout must be greater than zero")
 
-        source_url = (
-            f"https://www.smogon.com/stats/{month}/chaos/"
-            f"{normalized_format}-{cutoff}.json"
+        filename = f"{normalized_format}-{cutoff}.json"
+        source_url = f"https://www.smogon.com/stats/{month}/chaos/{filename}"
+        cache_filename = f"{filename}.gz" if compressed else filename
+        cache_path = (
+            Path(cache_dir) / month / cache_filename if cache_dir is not None else None
         )
 
+        if cache_path is not None and cache_path.is_file() and not refresh:
+            try:
+                stats = cls.from_file(cache_path, month=month, source_url=source_url)
+                _validate_snapshot_metadata(stats, normalized_format, cutoff)
+                return stats
+            except SmogonStatsError:
+                # A partial or otherwise invalid cache entry is replaced below.
+                pass
+
+        download_url = f"{source_url}.gz" if compressed else source_url
         try:
-            response = requests.get(source_url, timeout=timeout)
+            response = requests.get(download_url, timeout=timeout)
+            if response.status_code == 404 and compressed:
+                download_url = source_url
+                response = requests.get(download_url, timeout=timeout)
             if response.status_code == 404:
                 raise SmogonStatsNotFoundError(
                     f"Smogon stats snapshot not found: {source_url}"
@@ -107,26 +180,38 @@ class SmogonStats:
             raise
         except requests.RequestException as exc:
             raise SmogonStatsError(
-                f"Failed to fetch Smogon stats snapshot: {source_url}"
+                f"Failed to fetch Smogon stats snapshot: {download_url}"
             ) from exc
 
-        stats = cls.from_json(response.content, month=month, source_url=source_url)
-        if stats.battle_format != normalized_format or stats.cutoff != cutoff:
-            raise SmogonStatsParseError(
-                "Smogon stats metadata does not match the requested format and cutoff"
+        payload = (
+            _decompress(response.content, download_url)
+            if download_url.endswith(".gz")
+            else response.content
+        )
+        stats = cls.from_json(payload, month=month, source_url=source_url)
+        _validate_snapshot_metadata(stats, normalized_format, cutoff)
+        if cache_path is not None:
+            cache_payload = (
+                response.content
+                if download_url.endswith(".gz") or not compressed
+                else gzip.compress(response.content)
             )
+            _write_cache(cache_path, cache_payload)
         return stats
 
     @classmethod
     def from_file(
         cls, path: Union[str, Path], *, month: str, source_url: Optional[str] = None
     ) -> "SmogonStats":
-        """Parse a locally stored Smogon chaos JSON file."""
+        """Parse a locally stored Smogon chaos JSON or JSON.gz file."""
         file_path = Path(path)
         try:
             payload = file_path.read_bytes()
         except OSError as exc:
             raise SmogonStatsError(f"Failed to read Smogon stats file: {path}") from exc
+
+        if file_path.suffix == ".gz":
+            payload = _decompress(payload, str(file_path))
 
         return cls.from_json(
             payload, month=month, source_url=source_url or file_path.resolve().as_uri()
@@ -195,8 +280,7 @@ class SmogonStats:
         min_raw_count: int = 0,
     ) -> tuple[PokemonUsageStats, ...]:
         """Return Pokemon ordered by weighted usage, with optional filters."""
-        if limit is not None and limit < 0:
-            raise ValueError("limit must not be negative")
+        _validate_limit(limit)
         _validate_finite_number(min_usage, "min_usage")
         if min_usage < 0:
             raise ValueError("min_usage must not be negative")
@@ -249,6 +333,9 @@ def _parse_pokemon(name: str, document: Mapping[str, Any]) -> PokemonUsageStats:
         teammate_scores=_normalized_named_mapping(
             _weight_mapping(document["Teammates"], f"{name}.Teammates"), weighted_count
         ),
+        checks_and_counters=_counter_mapping(
+            document["Checks and Counters"], f"{name}.Checks and Counters"
+        ),
     )
 
 
@@ -288,6 +375,46 @@ def _spread_mapping(
         spread = Spread(nature=nature, evs=evs)
         spreads[spread] = spreads.get(spread, 0.0) + weight / denominator
     return MappingProxyType(spreads)
+
+
+def _counter_mapping(value: Any, field: str) -> Mapping[str, CounterStats]:
+    raw_mapping = _mapping(value, field)
+    counters = {}
+    for name, counter_document in raw_mapping.items():
+        counter_name = _string(name, f"{field} key")
+        counter_id = to_id_str(counter_name)
+        if not counter_id:
+            raise SmogonStatsParseError(f"{field} contains an empty Pokemon name")
+        if counter_id in counters:
+            raise SmogonStatsParseError(
+                f"{field} contains duplicate normalized Pokemon id: {counter_id}"
+            )
+
+        counter = _mapping(counter_document, f"{field}.{counter_name}")
+        weighted_encounters = _finite_number(counter["n"], f"{field}.{counter_name}.n")
+        probability = _finite_number(counter["p"], f"{field}.{counter_name}.p")
+        standard_error = _finite_number(counter["d"], f"{field}.{counter_name}.d")
+        if weighted_encounters <= 0:
+            raise SmogonStatsParseError(
+                f"{field}.{counter_name}.n must be greater than zero"
+            )
+        if not 0 <= probability <= 1:
+            raise SmogonStatsParseError(
+                f"{field}.{counter_name}.p must be between zero and one"
+            )
+        if standard_error < 0:
+            raise SmogonStatsParseError(
+                f"{field}.{counter_name}.d must not be negative"
+            )
+
+        counters[counter_id] = CounterStats(
+            id=counter_id,
+            name=counter_name,
+            weighted_encounters=weighted_encounters,
+            knockout_or_switch_probability=probability,
+            standard_error=standard_error,
+        )
+    return MappingProxyType(counters)
 
 
 def _weight_mapping(value: Any, field: str) -> Mapping[str, float]:
@@ -345,3 +472,45 @@ def _validate_non_negative_int(value: Any, field: str) -> None:
         _non_negative_int(value, field)
     except SmogonStatsParseError as exc:
         raise ValueError(str(exc)) from exc
+
+
+def _validate_limit(limit: Optional[int]) -> None:
+    if limit is not None:
+        _validate_non_negative_int(limit, "limit")
+
+
+def _decompress(payload: bytes, source: str) -> bytes:
+    try:
+        return gzip.decompress(payload)
+    except (OSError, EOFError) as exc:
+        raise SmogonStatsParseError(
+            f"Invalid gzip-compressed Smogon stats snapshot: {source}"
+        ) from exc
+
+
+def _validate_snapshot_metadata(
+    stats: SmogonStats, battle_format: str, cutoff: int
+) -> None:
+    if stats.battle_format != battle_format or stats.cutoff != cutoff:
+        raise SmogonStatsParseError(
+            "Smogon stats metadata does not match the requested format and cutoff"
+        )
+
+
+def _write_cache(path: Path, payload: bytes) -> None:
+    temporary_path: Optional[Path] = None
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with NamedTemporaryFile(
+            dir=path.parent, prefix=f".{path.name}.", suffix=".tmp", delete=False
+        ) as temporary_file:
+            temporary_file.write(payload)
+            temporary_path = Path(temporary_file.name)
+        temporary_path.replace(path)
+    except OSError as exc:
+        raise SmogonStatsError(
+            f"Failed to cache Smogon stats snapshot: {path}"
+        ) from exc
+    finally:
+        if temporary_path is not None:
+            temporary_path.unlink(missing_ok=True)

--- a/src/poke_env/data/smogon.py
+++ b/src/poke_env/data/smogon.py
@@ -53,7 +53,6 @@ class CounterStats:
     probability.
     """
 
-    id: str
     name: str
     weighted_encounters: float
     knockout_or_switch_probability: float
@@ -98,12 +97,12 @@ class PokemonUsageStats:
             raise ValueError("min_weighted_encounters must not be negative")
 
         matches = (
-            counter
-            for counter in self.checks_and_counters.values()
+            (counter_id, counter)
+            for counter_id, counter in self.checks_and_counters.items()
             if counter.weighted_encounters >= min_weighted_encounters
         )
-        ordered = sorted(matches, key=lambda counter: (-counter.score, counter.id))
-        return tuple(ordered[:limit])
+        ordered = sorted(matches, key=lambda item: (-item[1].score, item[0]))
+        return tuple(counter for _, counter in ordered[:limit])
 
 
 @dataclass(frozen=True, slots=True)
@@ -127,19 +126,17 @@ class SmogonStats:
         timeout: float = 30,
         cache_dir: Optional[Union[str, Path]] = _DEFAULT_CACHE_DIR,
         refresh: bool = False,
-        compressed: bool = True,
     ) -> "SmogonStats":
         """Fetch and parse a snapshot from Smogon's public chaos directory.
 
         ``month`` is deliberately explicit so experiments remain reproducible.
         The default ``cutoff=0`` selects Smogon's unweighted statistics.
 
-        Downloads use Smogon's gzip-compressed snapshots by default and are cached
-        under ``.poke_env_stats_cache`` in the current directory. Pass
-        ``cache_dir=None`` to disable caching, ``refresh=True`` to replace a cached
-        snapshot, or ``compressed=False`` to request uncompressed JSON. If a
-        compressed snapshot is unavailable, fetching falls back to uncompressed
-        JSON.
+        Downloads use Smogon's gzip-compressed snapshots and are cached under
+        ``.poke_env_stats_cache`` in the current directory. Pass ``cache_dir=None``
+        to disable caching or ``refresh=True`` to replace a cached snapshot. If a
+        compressed snapshot is unavailable, fetching falls back to uncompressed JSON
+        and stores the result in the canonical compressed cache format.
         """
         normalized_format = to_id_str(battle_format)
         if not normalized_format:
@@ -151,9 +148,10 @@ class SmogonStats:
 
         filename = f"{normalized_format}-{cutoff}.json"
         source_url = f"https://www.smogon.com/stats/{month}/chaos/{filename}"
-        cache_filename = f"{filename}.gz" if compressed else filename
         cache_path = (
-            Path(cache_dir) / month / cache_filename if cache_dir is not None else None
+            Path(cache_dir) / month / f"{filename}.gz"
+            if cache_dir is not None
+            else None
         )
 
         if cache_path is not None and cache_path.is_file() and not refresh:
@@ -165,10 +163,10 @@ class SmogonStats:
                 # A partial or otherwise invalid cache entry is replaced below.
                 pass
 
-        download_url = f"{source_url}.gz" if compressed else source_url
+        download_url = f"{source_url}.gz"
         try:
             response = requests.get(download_url, timeout=timeout)
-            if response.status_code == 404 and compressed:
+            if response.status_code == 404:
                 download_url = source_url
                 response = requests.get(download_url, timeout=timeout)
             if response.status_code == 404:
@@ -191,11 +189,9 @@ class SmogonStats:
         stats = cls.from_json(payload, month=month, source_url=source_url)
         _validate_snapshot_metadata(stats, normalized_format, cutoff)
         if cache_path is not None:
-            cache_payload = (
-                response.content
-                if download_url.endswith(".gz") or not compressed
-                else gzip.compress(response.content)
-            )
+            cache_payload = response.content
+            if not download_url.endswith(".gz"):
+                cache_payload = gzip.compress(cache_payload)
             _write_cache(cache_path, cache_payload)
         return stats
 
@@ -408,7 +404,6 @@ def _counter_mapping(value: Any, field: str) -> Mapping[str, CounterStats]:
             )
 
         counters[counter_id] = CounterStats(
-            id=counter_id,
             name=counter_name,
             weighted_encounters=weighted_encounters,
             knockout_or_switch_probability=probability,

--- a/src/poke_env/data/smogon.py
+++ b/src/poke_env/data/smogon.py
@@ -16,7 +16,9 @@ from poke_env.data.normalize import to_id_str
 
 JsonPayload = Union[str, bytes, bytearray, memoryview]
 _MONTH_PATTERN = re.compile(r"^[0-9]{4}-(0[1-9]|1[0-2])$")
+_MONTH_DIRECTORY_PATTERN = re.compile(r'href="([0-9]{4}-(?:0[1-9]|1[0-2]))/"')
 _DEFAULT_CACHE_DIR = Path(".poke_env_stats_cache")
+_STATS_INDEX_URL = "https://www.smogon.com/stats/"
 
 
 class SmogonStatsError(Exception):
@@ -121,7 +123,7 @@ class SmogonStats:
         cls,
         battle_format: str,
         *,
-        month: str,
+        month: str = "latest",
         cutoff: int = 0,
         timeout: float = 30,
         cache_dir: Optional[Union[str, Path]] = _DEFAULT_CACHE_DIR,
@@ -129,8 +131,9 @@ class SmogonStats:
     ) -> "SmogonStats":
         """Fetch and parse a snapshot from Smogon's public chaos directory.
 
-        ``month`` is deliberately explicit so experiments remain reproducible.
-        The default ``cutoff=0`` selects Smogon's unweighted statistics.
+        ``month`` defaults to the latest month listed in Smogon's stats index;
+        pass an explicit month for reproducible historical snapshots. The default
+        ``cutoff=0`` selects Smogon's unweighted statistics.
 
         Downloads use Smogon's gzip-compressed snapshots and are cached under
         ``.poke_env_stats_cache`` in the current directory. Pass ``cache_dir=None``
@@ -141,10 +144,13 @@ class SmogonStats:
         normalized_format = to_id_str(battle_format)
         if not normalized_format:
             raise ValueError("battle_format must not be empty")
-        _validate_month(month)
         _validate_non_negative_int(cutoff, "cutoff")
         if timeout <= 0:
             raise ValueError("timeout must be greater than zero")
+        if month == "latest":
+            month = _fetch_latest_month(timeout)
+        else:
+            _validate_month(month)
 
         filename = f"{normalized_format}-{cutoff}.json"
         source_url = f"https://www.smogon.com/stats/{month}/chaos/{filename}"
@@ -453,6 +459,24 @@ def _non_negative_int(value: Any, field: str) -> int:
 def _validate_month(month: str) -> None:
     if not isinstance(month, str) or not _MONTH_PATTERN.fullmatch(month):
         raise ValueError("month must use YYYY-MM format")
+
+
+def _fetch_latest_month(timeout: float) -> str:
+    try:
+        response = requests.get(_STATS_INDEX_URL, timeout=timeout)
+        response.raise_for_status()
+        index = response.content.decode("utf-8")
+    except (requests.RequestException, UnicodeDecodeError) as exc:
+        raise SmogonStatsError(
+            "Failed to determine the latest Smogon stats month"
+        ) from exc
+
+    months = _MONTH_DIRECTORY_PATTERN.findall(index)
+    if not months:
+        raise SmogonStatsParseError(
+            "Smogon stats index does not contain any monthly snapshots"
+        )
+    return max(months)
 
 
 def _validate_finite_number(value: Any, field: str) -> None:

--- a/unit_tests/data/test_smogon.py
+++ b/unit_tests/data/test_smogon.py
@@ -253,6 +253,32 @@ def test_fetch_uses_explicit_snapshot(monkeypatch, chaos_payload):
     )
 
 
+def test_fetch_defaults_to_latest_month(monkeypatch, chaos_payload):
+    index = (
+        b'<a href="2026-05/">2026-05/</a>'
+        b'<a href="2026-06-DLC1/">DLC</a>'
+        b'<a href="2026-06/">2026-06/</a>'
+    )
+    response = FakeResponse(gzip.compress(chaos_payload))
+    requested_urls = []
+
+    def get(url, *, timeout):
+        requested_urls.append((url, timeout))
+        if url == "https://www.smogon.com/stats/":
+            return FakeResponse(index)
+        return response
+
+    monkeypatch.setattr("poke_env.data.smogon.requests.get", get)
+
+    stats = SmogonStats.fetch("gen9ou", cutoff=1695, cache_dir=None)
+
+    assert stats.month == "2026-06"
+    assert requested_urls == [
+        ("https://www.smogon.com/stats/", 30),
+        ("https://www.smogon.com/stats/2026-06/chaos/gen9ou-1695.json.gz", 30),
+    ]
+
+
 def test_fetch_defaults_to_unweighted_snapshot(monkeypatch, chaos_document):
     chaos_document["info"]["cutoff"] = 0
     response = FakeResponse(gzip.compress(orjson.dumps(chaos_document)))

--- a/unit_tests/data/test_smogon.py
+++ b/unit_tests/data/test_smogon.py
@@ -75,6 +75,16 @@ def chaos_payload(chaos_document):
     return orjson.dumps(chaos_document)
 
 
+class FakeResponse:
+    def __init__(self, content: bytes = b"", status_code: int = 200):
+        self.content = content
+        self.status_code = status_code
+
+    @staticmethod
+    def raise_for_status():
+        return None
+
+
 def test_from_json_parses_and_normalizes_chaos_data(chaos_payload):
     stats = SmogonStats.from_json(
         chaos_payload,
@@ -108,14 +118,12 @@ def test_from_json_parses_and_normalizes_chaos_data(chaos_payload):
     }
     assert great_tusk.checks_and_counters == {
         "hatterene": CounterStats(
-            id="hatterene",
             name="Hatterene",
             weighted_encounters=100.0,
             knockout_or_switch_probability=0.7,
             standard_error=0.04,
         ),
         "dondozo": CounterStats(
-            id="dondozo",
             name="Dondozo",
             weighted_encounters=200.0,
             knockout_or_switch_probability=0.72,
@@ -137,7 +145,7 @@ def test_snapshot_mappings_are_read_only(chaos_payload):
         stats["pikachu"].moves["thunder"] = 1.0
     with pytest.raises(TypeError):
         stats["greattusk"].checks_and_counters["corviknight"] = CounterStats(
-            "corviknight", "Corviknight", 100, 0.5, 0.05
+            "Corviknight", 100, 0.5, 0.05
         )
 
 
@@ -220,20 +228,14 @@ def test_from_file_reads_compressed_snapshot(tmp_path: Path, chaos_payload):
 
 
 def test_fetch_uses_explicit_snapshot(monkeypatch, chaos_payload):
-    class Response:
-        status_code = 200
-        content = gzip.compress(chaos_payload)
-
-        @staticmethod
-        def raise_for_status():
-            return None
+    response = FakeResponse(gzip.compress(chaos_payload))
 
     request = {}
 
     def get(url, *, timeout):
         request["url"] = url
         request["timeout"] = timeout
-        return Response()
+        return response
 
     monkeypatch.setattr("poke_env.data.smogon.requests.get", get)
 
@@ -253,21 +255,14 @@ def test_fetch_uses_explicit_snapshot(monkeypatch, chaos_payload):
 
 def test_fetch_defaults_to_unweighted_snapshot(monkeypatch, chaos_document):
     chaos_document["info"]["cutoff"] = 0
-
-    class Response:
-        status_code = 200
-        content = gzip.compress(orjson.dumps(chaos_document))
-
-        @staticmethod
-        def raise_for_status():
-            return None
+    response = FakeResponse(gzip.compress(orjson.dumps(chaos_document)))
 
     request = {}
 
     def get(url, *, timeout):
         request["url"] = url
         request["timeout"] = timeout
-        return Response()
+        return response
 
     monkeypatch.setattr("poke_env.data.smogon.requests.get", get)
 
@@ -283,19 +278,13 @@ def test_fetch_defaults_to_unweighted_snapshot(monkeypatch, chaos_document):
 def test_fetch_caches_compressed_snapshot_by_default(
     monkeypatch, tmp_path: Path, chaos_payload
 ):
-    class Response:
-        status_code = 200
-        content = gzip.compress(chaos_payload)
-
-        @staticmethod
-        def raise_for_status():
-            return None
+    response = FakeResponse(gzip.compress(chaos_payload))
 
     requests_made = []
 
     def get(url, *, timeout):
         requests_made.append((url, timeout))
-        return Response()
+        return response
 
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr("poke_env.data.smogon.requests.get", get)
@@ -304,66 +293,36 @@ def test_fetch_caches_compressed_snapshot_by_default(
     cached = SmogonStats.fetch("gen9ou", month="2026-06", cutoff=1695)
 
     cache_path = tmp_path / ".poke_env_stats_cache/2026-06/gen9ou-1695.json.gz"
-    assert cache_path.read_bytes() == Response.content
+    assert cache_path.read_bytes() == response.content
     assert requests_made == [
         ("https://www.smogon.com/stats/2026-06/chaos/gen9ou-1695.json.gz", 30)
     ]
     assert cached == downloaded
 
 
-def test_fetch_can_request_uncompressed_snapshot(monkeypatch, chaos_payload):
-    class Response:
-        status_code = 200
-        content = chaos_payload
-
-        @staticmethod
-        def raise_for_status():
-            return None
-
-    request = {}
-
-    def get(url, *, timeout):
-        request["url"] = url
-        request["timeout"] = timeout
-        return Response()
-
-    monkeypatch.setattr("poke_env.data.smogon.requests.get", get)
-
-    stats = SmogonStats.fetch(
-        "gen9ou", month="2026-06", cutoff=1695, cache_dir=None, compressed=False
-    )
-
-    assert request["url"].endswith("/gen9ou-1695.json")
-    assert stats["greattusk"].usage == 0.25
-
-
 def test_fetch_falls_back_when_compressed_snapshot_is_missing(
-    monkeypatch, chaos_payload
+    monkeypatch, tmp_path: Path, chaos_payload
 ):
-    class Response:
-        def __init__(self, status_code, content=b""):
-            self.status_code = status_code
-            self.content = content
-
-        def raise_for_status(self):
-            return None
-
     requested_urls = []
 
     def get(url, *, timeout):
         requested_urls.append(url)
         if url.endswith(".gz"):
-            return Response(404)
-        return Response(200, chaos_payload)
+            return FakeResponse(status_code=404)
+        return FakeResponse(chaos_payload)
 
     monkeypatch.setattr("poke_env.data.smogon.requests.get", get)
 
-    stats = SmogonStats.fetch("gen9ou", month="2026-06", cutoff=1695, cache_dir=None)
+    stats = SmogonStats.fetch(
+        "gen9ou", month="2026-06", cutoff=1695, cache_dir=tmp_path
+    )
 
     assert requested_urls == [
         "https://www.smogon.com/stats/2026-06/chaos/gen9ou-1695.json.gz",
         "https://www.smogon.com/stats/2026-06/chaos/gen9ou-1695.json",
     ]
+    cache_path = tmp_path / "2026-06/gen9ou-1695.json.gz"
+    assert gzip.decompress(cache_path.read_bytes()) == chaos_payload
     assert stats["greattusk"].usage == 0.25
 
 
@@ -374,32 +333,24 @@ def test_fetch_replaces_invalid_cached_snapshot(
     cache_path.parent.mkdir()
     cache_path.write_bytes(b"invalid")
 
-    class Response:
-        status_code = 200
-        content = gzip.compress(chaos_payload)
-
-        @staticmethod
-        def raise_for_status():
-            return None
+    response = FakeResponse(gzip.compress(chaos_payload))
 
     monkeypatch.setattr(
-        "poke_env.data.smogon.requests.get", lambda *args, **kwargs: Response()
+        "poke_env.data.smogon.requests.get", lambda *args, **kwargs: response
     )
 
     stats = SmogonStats.fetch(
         "gen9ou", month="2026-06", cutoff=1695, cache_dir=tmp_path
     )
 
-    assert cache_path.read_bytes() == Response.content
+    assert cache_path.read_bytes() == response.content
     assert stats["greattusk"].usage == 0.25
 
 
 def test_fetch_reports_missing_snapshot(monkeypatch):
-    class Response:
-        status_code = 404
-
     monkeypatch.setattr(
-        "poke_env.data.smogon.requests.get", lambda *args, **kwargs: Response()
+        "poke_env.data.smogon.requests.get",
+        lambda *args, **kwargs: FakeResponse(status_code=404),
     )
 
     with pytest.raises(SmogonStatsNotFoundError, match="not found"):

--- a/unit_tests/data/test_smogon.py
+++ b/unit_tests/data/test_smogon.py
@@ -1,10 +1,12 @@
+import gzip
 from pathlib import Path
 
 import orjson
 import pytest
 import requests
 
-from poke_env.data.smogon import (
+from poke_env.data import (
+    CounterStats,
     SmogonStats,
     SmogonStatsError,
     SmogonStatsNotFoundError,
@@ -43,7 +45,10 @@ def chaos_document():
                 },
                 "Tera Types": {"Steel": 3.0, "Water": 1.0},
                 "Teammates": {"Gholdengo": 1.2, "Corviknight": -0.4, "Kingambit": 0.0},
-                "Checks and Counters": {},
+                "Checks and Counters": {
+                    "Hatterene": {"n": 100.0, "p": 0.7, "d": 0.04},
+                    "Dondozo": {"n": 200.0, "p": 0.72, "d": 0.02},
+                },
                 "usage": 0.25,
             },
             "Pikachu": {
@@ -101,6 +106,23 @@ def test_from_json_parses_and_normalizes_chaos_data(chaos_payload):
         Spread("Jolly", (0, 252, 4, 0, 0, 252)): 0.75,
         Spread("Impish", (252, 0, 252, 0, 4, 0)): 0.25,
     }
+    assert great_tusk.checks_and_counters == {
+        "hatterene": CounterStats(
+            id="hatterene",
+            name="Hatterene",
+            weighted_encounters=100.0,
+            knockout_or_switch_probability=0.7,
+            standard_error=0.04,
+        ),
+        "dondozo": CounterStats(
+            id="dondozo",
+            name="Dondozo",
+            weighted_encounters=200.0,
+            knockout_or_switch_probability=0.72,
+            standard_error=0.02,
+        ),
+    }
+    assert great_tusk.checks_and_counters["dondozo"].score == pytest.approx(0.64)
 
     assert stats["Pikachu"].tera_types == {}
     assert stats.get("missingno") is None
@@ -113,6 +135,10 @@ def test_snapshot_mappings_are_read_only(chaos_payload):
         stats.pokemon["eevee"] = stats["pikachu"]
     with pytest.raises(TypeError):
         stats["pikachu"].moves["thunder"] = 1.0
+    with pytest.raises(TypeError):
+        stats["greattusk"].checks_and_counters["corviknight"] = CounterStats(
+            "corviknight", "Corviknight", 100, 0.5, 0.05
+        )
 
 
 def test_top_pokemon_filters_and_orders(chaos_payload):
@@ -125,10 +151,42 @@ def test_top_pokemon_filters_and_orders(chaos_payload):
     assert stats.top_pokemon(limit=0) == ()
 
 
+def test_top_counters_filters_and_orders(chaos_payload):
+    stats = SmogonStats.from_json(chaos_payload, month="2026-06")
+
+    great_tusk = stats["greattusk"]
+    assert great_tusk.top_counters() == (
+        great_tusk.checks_and_counters["dondozo"],
+        great_tusk.checks_and_counters["hatterene"],
+    )
+    assert great_tusk.top_counters(1) == (great_tusk.checks_and_counters["dondozo"],)
+    assert great_tusk.top_counters(min_weighted_encounters=150) == (
+        great_tusk.checks_and_counters["dondozo"],
+    )
+    assert great_tusk.top_counters(limit=0) == ()
+
+
 @pytest.mark.parametrize(
     ("kwargs", "message"),
     [
         ({"limit": -1}, "limit"),
+        ({"limit": 1.5}, "limit"),
+        ({"min_weighted_encounters": -0.1}, "min_weighted_encounters"),
+        ({"min_weighted_encounters": float("nan")}, "min_weighted_encounters"),
+    ],
+)
+def test_top_counters_rejects_invalid_filters(chaos_payload, kwargs, message):
+    stats = SmogonStats.from_json(chaos_payload, month="2026-06")
+
+    with pytest.raises(ValueError, match=message):
+        stats["greattusk"].top_counters(**kwargs)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"limit": -1}, "limit"),
+        ({"limit": 1.5}, "limit"),
         ({"min_usage": -0.1}, "min_usage"),
         ({"min_usage": float("nan")}, "min_usage"),
         ({"min_raw_count": -1}, "min_raw_count"),
@@ -151,7 +209,109 @@ def test_from_file_reads_local_snapshot(tmp_path: Path, chaos_payload):
     assert stats.source_url == snapshot.resolve().as_uri()
 
 
+def test_from_file_reads_compressed_snapshot(tmp_path: Path, chaos_payload):
+    snapshot = tmp_path / "gen9ou-1695.json.gz"
+    snapshot.write_bytes(gzip.compress(chaos_payload))
+
+    stats = SmogonStats.from_file(snapshot, month="2026-06")
+
+    assert stats["Great Tusk"].usage == 0.25
+    assert stats.source_url == snapshot.resolve().as_uri()
+
+
 def test_fetch_uses_explicit_snapshot(monkeypatch, chaos_payload):
+    class Response:
+        status_code = 200
+        content = gzip.compress(chaos_payload)
+
+        @staticmethod
+        def raise_for_status():
+            return None
+
+    request = {}
+
+    def get(url, *, timeout):
+        request["url"] = url
+        request["timeout"] = timeout
+        return Response()
+
+    monkeypatch.setattr("poke_env.data.smogon.requests.get", get)
+
+    stats = SmogonStats.fetch(
+        "Gen 9 OU", month="2026-06", cutoff=1695, timeout=12, cache_dir=None
+    )
+
+    assert request == {
+        "url": "https://www.smogon.com/stats/2026-06/chaos/gen9ou-1695.json.gz",
+        "timeout": 12,
+    }
+    assert stats.battle_format == "gen9ou"
+    assert stats.source_url == (
+        "https://www.smogon.com/stats/2026-06/chaos/gen9ou-1695.json"
+    )
+
+
+def test_fetch_defaults_to_unweighted_snapshot(monkeypatch, chaos_document):
+    chaos_document["info"]["cutoff"] = 0
+
+    class Response:
+        status_code = 200
+        content = gzip.compress(orjson.dumps(chaos_document))
+
+        @staticmethod
+        def raise_for_status():
+            return None
+
+    request = {}
+
+    def get(url, *, timeout):
+        request["url"] = url
+        request["timeout"] = timeout
+        return Response()
+
+    monkeypatch.setattr("poke_env.data.smogon.requests.get", get)
+
+    stats = SmogonStats.fetch("Gen 9 OU", month="2026-06", cache_dir=None)
+
+    assert request == {
+        "url": "https://www.smogon.com/stats/2026-06/chaos/gen9ou-0.json.gz",
+        "timeout": 30,
+    }
+    assert stats.cutoff == 0
+
+
+def test_fetch_caches_compressed_snapshot_by_default(
+    monkeypatch, tmp_path: Path, chaos_payload
+):
+    class Response:
+        status_code = 200
+        content = gzip.compress(chaos_payload)
+
+        @staticmethod
+        def raise_for_status():
+            return None
+
+    requests_made = []
+
+    def get(url, *, timeout):
+        requests_made.append((url, timeout))
+        return Response()
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("poke_env.data.smogon.requests.get", get)
+
+    downloaded = SmogonStats.fetch("gen9ou", month="2026-06", cutoff=1695)
+    cached = SmogonStats.fetch("gen9ou", month="2026-06", cutoff=1695)
+
+    cache_path = tmp_path / ".poke_env_stats_cache/2026-06/gen9ou-1695.json.gz"
+    assert cache_path.read_bytes() == Response.content
+    assert requests_made == [
+        ("https://www.smogon.com/stats/2026-06/chaos/gen9ou-1695.json.gz", 30)
+    ]
+    assert cached == downloaded
+
+
+def test_fetch_can_request_uncompressed_snapshot(monkeypatch, chaos_payload):
     class Response:
         status_code = 200
         content = chaos_payload
@@ -169,42 +329,69 @@ def test_fetch_uses_explicit_snapshot(monkeypatch, chaos_payload):
 
     monkeypatch.setattr("poke_env.data.smogon.requests.get", get)
 
-    stats = SmogonStats.fetch("Gen 9 OU", month="2026-06", cutoff=1695, timeout=12)
+    stats = SmogonStats.fetch(
+        "gen9ou", month="2026-06", cutoff=1695, cache_dir=None, compressed=False
+    )
 
-    assert request == {
-        "url": "https://www.smogon.com/stats/2026-06/chaos/gen9ou-1695.json",
-        "timeout": 12,
-    }
-    assert stats.battle_format == "gen9ou"
+    assert request["url"].endswith("/gen9ou-1695.json")
+    assert stats["greattusk"].usage == 0.25
 
 
-def test_fetch_defaults_to_unweighted_snapshot(monkeypatch, chaos_document):
-    chaos_document["info"]["cutoff"] = 0
+def test_fetch_falls_back_when_compressed_snapshot_is_missing(
+    monkeypatch, chaos_payload
+):
+    class Response:
+        def __init__(self, status_code, content=b""):
+            self.status_code = status_code
+            self.content = content
+
+        def raise_for_status(self):
+            return None
+
+    requested_urls = []
+
+    def get(url, *, timeout):
+        requested_urls.append(url)
+        if url.endswith(".gz"):
+            return Response(404)
+        return Response(200, chaos_payload)
+
+    monkeypatch.setattr("poke_env.data.smogon.requests.get", get)
+
+    stats = SmogonStats.fetch("gen9ou", month="2026-06", cutoff=1695, cache_dir=None)
+
+    assert requested_urls == [
+        "https://www.smogon.com/stats/2026-06/chaos/gen9ou-1695.json.gz",
+        "https://www.smogon.com/stats/2026-06/chaos/gen9ou-1695.json",
+    ]
+    assert stats["greattusk"].usage == 0.25
+
+
+def test_fetch_replaces_invalid_cached_snapshot(
+    monkeypatch, tmp_path: Path, chaos_payload
+):
+    cache_path = tmp_path / "2026-06/gen9ou-1695.json.gz"
+    cache_path.parent.mkdir()
+    cache_path.write_bytes(b"invalid")
 
     class Response:
         status_code = 200
-        content = orjson.dumps(chaos_document)
+        content = gzip.compress(chaos_payload)
 
         @staticmethod
         def raise_for_status():
             return None
 
-    request = {}
+    monkeypatch.setattr(
+        "poke_env.data.smogon.requests.get", lambda *args, **kwargs: Response()
+    )
 
-    def get(url, *, timeout):
-        request["url"] = url
-        request["timeout"] = timeout
-        return Response()
+    stats = SmogonStats.fetch(
+        "gen9ou", month="2026-06", cutoff=1695, cache_dir=tmp_path
+    )
 
-    monkeypatch.setattr("poke_env.data.smogon.requests.get", get)
-
-    stats = SmogonStats.fetch("Gen 9 OU", month="2026-06")
-
-    assert request == {
-        "url": "https://www.smogon.com/stats/2026-06/chaos/gen9ou-0.json",
-        "timeout": 30,
-    }
-    assert stats.cutoff == 0
+    assert cache_path.read_bytes() == Response.content
+    assert stats["greattusk"].usage == 0.25
 
 
 def test_fetch_reports_missing_snapshot(monkeypatch):
@@ -216,7 +403,7 @@ def test_fetch_reports_missing_snapshot(monkeypatch):
     )
 
     with pytest.raises(SmogonStatsNotFoundError, match="not found"):
-        SmogonStats.fetch("gen9ou", month="2026-06", cutoff=1825)
+        SmogonStats.fetch("gen9ou", month="2026-06", cutoff=1825, cache_dir=None)
 
 
 def test_fetch_wraps_request_errors(monkeypatch):
@@ -226,7 +413,7 @@ def test_fetch_wraps_request_errors(monkeypatch):
     monkeypatch.setattr("poke_env.data.smogon.requests.get", fail)
 
     with pytest.raises(SmogonStatsError, match="Failed to fetch"):
-        SmogonStats.fetch("gen9ou", month="2026-06", cutoff=1695)
+        SmogonStats.fetch("gen9ou", month="2026-06", cutoff=1695, cache_dir=None)
 
 
 @pytest.mark.parametrize("month", ["2026-6", "2026-13", "latest", ""])
@@ -251,4 +438,16 @@ def test_parser_rejects_invalid_spread(chaos_document):
     chaos_document["data"]["Pikachu"]["Spreads"] = {"Timid:252/252": 0.5}
 
     with pytest.raises(SmogonStatsParseError, match="Invalid spread"):
+        SmogonStats.from_json(orjson.dumps(chaos_document), month="2026-06")
+
+
+@pytest.mark.parametrize(
+    ("field", "value"), [("n", 0), ("p", -0.1), ("p", 1.1), ("d", -0.1)]
+)
+def test_parser_rejects_invalid_counter_stats(chaos_document, field, value):
+    chaos_document["data"]["Great Tusk"]["Checks and Counters"]["Hatterene"][
+        field
+    ] = value
+
+    with pytest.raises(SmogonStatsParseError, match="Checks and Counters"):
         SmogonStats.from_json(orjson.dumps(chaos_document), month="2026-06")


### PR DESCRIPTION
Add checks-and-counters support and cache compressed Smogon snapshots by default so agents can use counter data without repeatedly downloading large monthly files.

## What changed

- Parse immutable checks-and-counters records and rank them by Smogon's conservative score.
- Download gzip snapshots by default, cache them in `.poke_env_stats_cache`, and fall back to uncompressed historical snapshots.
- Export the Smogon data types and document the public API.

## Validation

- `.venv/bin/pytest -q unit_tests/`
- `.venv/bin/black --check src/ unit_tests/ integration_tests/`
- `.venv/bin/flake8 src/ unit_tests/ integration_tests/`
- `.venv/bin/isort --check .`
- `.venv/bin/mypy src`
- `.venv/bin/python scripts/check_docs_links.py`
- `LC_ALL=C LANG=C .venv/bin/python -m sphinx -b html -W docs/source docs/_build/html`