### PR TITLE
Add Smogon stats teambuilder

### DIFF
--- a/docs/source/examples/index.rst
+++ b/docs/source/examples/index.rst
@@ -13,6 +13,8 @@ Choose an Example
   local Showdown server.
 - :doc:`using_a_custom_teambuilder`: custom team selection and generation;
   requires a local Showdown server.
+- :doc:`smogon_stats_teambuilder`: complete a partial team from Smogon usage
+  statistics; no Showdown server is required.
 - :doc:`connecting_to_showdown_and_challenging_humans`: connecting to the
   official or a custom server and interacting with human players; an account is
   required for the public server.
@@ -32,6 +34,7 @@ Choose an Example
 
     quickstart
     using_a_custom_teambuilder
+    smogon_stats_teambuilder
     connecting_to_showdown_and_challenging_humans
     tracking_observations
     reinforcement_learning

--- a/docs/source/examples/smogon_stats_teambuilder.rst
+++ b/docs/source/examples/smogon_stats_teambuilder.rst
@@ -6,6 +6,13 @@ statistics snapshot. It uses the snapshot's overall usage and teammate data to
 choose species, then fills in each Pokémon's missing ability, item, spread,
 moves, and Tera type from that Pokémon's marginal frequencies.
 
+For a reusable builder, load a snapshot directly or use
+``SmogonStatsTeambuilder.from_format("gen9ou")``. Its ``yield_team`` method
+returns the packed format expected by ``Player``. For one-off use, the
+``generate_team`` and ``complete_team`` helpers return lists of
+``TeambuilderPokemon`` objects, which can be inspected or modified before being
+packed with ``Teambuilder.join_team``.
+
 Team and Pokémon completion are controlled independently:
 
 ``team_strategy``

--- a/docs/source/examples/smogon_stats_teambuilder.rst
+++ b/docs/source/examples/smogon_stats_teambuilder.rst
@@ -30,6 +30,6 @@ completion or greedy species with sampled set completion. A seeded
 .. literalinclude:: ../../../examples/smogon_stats_teambuilder.py
    :language: python
 
-The teammate data contains pairwise information rather than complete team
-observations, so the generated team is a practical completion based on those
-pairwise signals, not an exact reconstruction of the full team distribution.
+The teammate statistics describe pairs of Pokémon, not complete teams. The
+builder uses them to make a plausible team, but it does not reproduce the
+original team distribution exactly.

--- a/docs/source/examples/smogon_stats_teambuilder.rst
+++ b/docs/source/examples/smogon_stats_teambuilder.rst
@@ -1,0 +1,28 @@
+Smogon stats teambuilder
+========================
+
+``SmogonStatsTeambuilder`` completes a partial team from one Smogon usage
+statistics snapshot. It uses the snapshot's overall usage and teammate data to
+choose species, then fills in each Pokémon's missing ability, item, spread,
+moves, and Tera type from that Pokémon's marginal frequencies.
+
+Team and Pokémon completion are controlled independently:
+
+``team_strategy``
+   ``"greedy"`` chooses the highest-weight species at each step. ``"sample"``
+   draws each species from the current team-conditioned distribution.
+
+``pokemon_strategy``
+   ``"greedy"`` chooses the most frequent missing set values. ``"sample"``
+   draws each missing value from its marginal distribution.
+
+This gives all four combinations, for example sampled species with greedy set
+completion or greedy species with sampled set completion. A seeded
+``random.Random`` makes sampled completions reproducible.
+
+.. literalinclude:: ../../../examples/smogon_stats_teambuilder.py
+   :language: python
+
+The teammate data contains pairwise information rather than complete team
+observations, so the generated team is a practical completion based on those
+pairwise signals, not an exact reconstruction of the full team distribution.

--- a/docs/source/modules/teambuilder.rst
+++ b/docs/source/modules/teambuilder.rst
@@ -21,6 +21,14 @@ Constant teambuilder
    :undoc-members:
    :show-inheritance:
 
+Smogon stats teambuilder
+*************************
+
+.. automodule:: poke_env.teambuilder.smogon_stats_teambuilder
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 Teambuilder pokemon
 *******************
 

--- a/examples/smogon_stats_teambuilder.py
+++ b/examples/smogon_stats_teambuilder.py
@@ -2,24 +2,40 @@
 
 from random import Random
 
-from poke_env.data import SmogonStats
-from poke_env.teambuilder import SmogonStatsTeambuilder, TeambuilderPokemon
+from poke_env.teambuilder import (
+    SmogonStatsTeambuilder,
+    Teambuilder,
+    TeambuilderPokemon,
+    complete_team,
+    generate_team,
+)
 
 
 def main() -> None:
-    stats = SmogonStats.fetch("gen9ou", month="latest")
-    partial_team = [TeambuilderPokemon(species=stats.top_pokemon(limit=1)[0].name)]
+    generated = generate_team(
+        "gen9ou", team_strategy="sample", pokemon_strategy="greedy", rng=Random(7)
+    )
+    print("Generated structured team:")
+    print([pokemon.species for pokemon in generated])
+    print("Packed team:")
+    print(Teambuilder.join_team(generated))
 
-    for team_strategy, pokemon_strategy in (("greedy", "sample"), ("sample", "greedy")):
-        builder = SmogonStatsTeambuilder(
-            stats,
-            partial_team,
-            team_strategy=team_strategy,
-            pokemon_strategy=pokemon_strategy,
-            rng=Random(7),
-        )
-        print(f"{team_strategy=}, {pokemon_strategy=}")
-        print(builder.yield_team())
+    partial_team = [TeambuilderPokemon(species=generated[0].species)]
+    completed = complete_team(
+        partial_team,
+        "gen9ou",
+        team_strategy="sample",
+        pokemon_strategy="greedy",
+        rng=Random(7),
+    )
+    print("Completed partial team:")
+    print(Teambuilder.join_team(completed))
+
+    builder = SmogonStatsTeambuilder.from_format(
+        "gen9ou", team_strategy="greedy", pokemon_strategy="sample", rng=Random(7)
+    )
+    print("Reusable builder:")
+    print(builder.yield_team())
 
 
 if __name__ == "__main__":

--- a/examples/smogon_stats_teambuilder.py
+++ b/examples/smogon_stats_teambuilder.py
@@ -1,0 +1,26 @@
+"""Complete a partial team with Smogon's usage statistics."""
+
+from random import Random
+
+from poke_env.data import SmogonStats
+from poke_env.teambuilder import SmogonStatsTeambuilder, TeambuilderPokemon
+
+
+def main() -> None:
+    stats = SmogonStats.fetch("gen9ou", month="latest")
+    partial_team = [TeambuilderPokemon(species=stats.top_pokemon(limit=1)[0].name)]
+
+    for team_strategy, pokemon_strategy in (("greedy", "sample"), ("sample", "greedy")):
+        builder = SmogonStatsTeambuilder(
+            stats,
+            partial_team,
+            team_strategy=team_strategy,
+            pokemon_strategy=pokemon_strategy,
+            rng=Random(7),
+        )
+        print(f"{team_strategy=}, {pokemon_strategy=}")
+        print(builder.yield_team())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/poke_env/teambuilder/__init__.py
+++ b/src/poke_env/teambuilder/__init__.py
@@ -1,7 +1,13 @@
 """poke_env.teambuilder module init."""
 
 from poke_env.teambuilder.constant_teambuilder import ConstantTeambuilder
+from poke_env.teambuilder.smogon_stats_teambuilder import SmogonStatsTeambuilder
 from poke_env.teambuilder.teambuilder import Teambuilder
 from poke_env.teambuilder.teambuilder_pokemon import TeambuilderPokemon
 
-__all__ = ["ConstantTeambuilder", "Teambuilder", "TeambuilderPokemon"]
+__all__ = [
+    "ConstantTeambuilder",
+    "SmogonStatsTeambuilder",
+    "Teambuilder",
+    "TeambuilderPokemon",
+]

--- a/src/poke_env/teambuilder/__init__.py
+++ b/src/poke_env/teambuilder/__init__.py
@@ -1,7 +1,11 @@
 """poke_env.teambuilder module init."""
 
 from poke_env.teambuilder.constant_teambuilder import ConstantTeambuilder
-from poke_env.teambuilder.smogon_stats_teambuilder import SmogonStatsTeambuilder
+from poke_env.teambuilder.smogon_stats_teambuilder import (
+    SmogonStatsTeambuilder,
+    complete_team,
+    generate_team,
+)
 from poke_env.teambuilder.teambuilder import Teambuilder
 from poke_env.teambuilder.teambuilder_pokemon import TeambuilderPokemon
 
@@ -10,4 +14,6 @@ __all__ = [
     "SmogonStatsTeambuilder",
     "Teambuilder",
     "TeambuilderPokemon",
+    "complete_team",
+    "generate_team",
 ]

--- a/src/poke_env/teambuilder/smogon_stats_teambuilder.py
+++ b/src/poke_env/teambuilder/smogon_stats_teambuilder.py
@@ -2,8 +2,9 @@
 
 from copy import deepcopy
 from math import prod
+from pathlib import Path
 from random import Random
-from typing import Literal, Mapping, Optional, Sequence, TypeVar
+from typing import Literal, Mapping, Optional, Sequence, TypeVar, Union
 
 from poke_env.data.normalize import to_id_str
 from poke_env.data.smogon import PokemonUsageStats, SmogonStats
@@ -78,8 +79,60 @@ class SmogonStatsTeambuilder(Teambuilder):
             if len(set(map(to_id_str, pokemon.moves))) != len(pokemon.moves):
                 raise ValueError(f"{pokemon.species} has duplicate specified moves")
 
+    @classmethod
+    def from_format(
+        cls,
+        battle_format: str,
+        team: Sequence[TeambuilderPokemon] = (),
+        *,
+        month: str = "latest",
+        cutoff: int = 0,
+        timeout: float = 30,
+        cache_dir: Optional[Union[str, Path]] = ".poke_env_stats_cache",
+        refresh: bool = False,
+        team_strategy: Strategy = "greedy",
+        pokemon_strategy: Strategy = "greedy",
+        rng: Optional[Random] = None,
+    ) -> "SmogonStatsTeambuilder":
+        """Create a teambuilder from a Smogon statistics format.
+
+        This is a convenience wrapper around :meth:`SmogonStats.fetch`. Use the
+        constructor directly when a parsed snapshot is already available.
+
+        :param battle_format: Format whose Smogon statistics should be used.
+        :param team: Partially specified Pokemon to retain and complete.
+        :param month: Statistics month, or ``"latest"``.
+        :param cutoff: Smogon rating cutoff for the statistics snapshot.
+        :param timeout: HTTP timeout used when fetching statistics.
+        :param cache_dir: Directory used for cached snapshots. Set to ``None`` to
+            disable caching.
+        :param refresh: Whether to replace an existing cached snapshot.
+        :param team_strategy: Strategy used to select missing species.
+        :param pokemon_strategy: Strategy used to complete missing set values.
+        :param rng: Source of randomness for sampled choices.
+        """
+        stats = SmogonStats.fetch(
+            battle_format,
+            month=month,
+            cutoff=cutoff,
+            timeout=timeout,
+            cache_dir=cache_dir,
+            refresh=refresh,
+        )
+        return cls(
+            stats,
+            team,
+            team_strategy=team_strategy,
+            pokemon_strategy=pokemon_strategy,
+            rng=rng,
+        )
+
     def yield_team(self) -> str:
         """Return a packed completed team."""
+        return self.join_team(self._build_team())
+
+    def _build_team(self) -> list[TeambuilderPokemon]:
+        """Return a structured completed team for the public convenience helpers."""
         team = [deepcopy(pokemon) for pokemon in self._team]
         selected_stats = [self._usage_for(pokemon) for pokemon in team]
 
@@ -90,7 +143,7 @@ class SmogonStatsTeambuilder(Teambuilder):
 
         for pokemon in team:
             self._complete_pokemon(pokemon, self._usage_for(pokemon))
-        return self.join_team(team)
+        return team
 
     def _usage_for(self, pokemon: TeambuilderPokemon) -> PokemonUsageStats:
         assert pokemon.species is not None
@@ -201,3 +254,71 @@ class SmogonStatsTeambuilder(Teambuilder):
             if threshold <= 0:
                 return value
         return ordered[-1]
+
+
+def generate_team(
+    battle_format: str,
+    *,
+    month: str = "latest",
+    cutoff: int = 0,
+    timeout: float = 30,
+    cache_dir: Optional[Union[str, Path]] = ".poke_env_stats_cache",
+    refresh: bool = False,
+    team_strategy: Strategy = "greedy",
+    pokemon_strategy: Strategy = "greedy",
+    rng: Optional[Random] = None,
+) -> list[TeambuilderPokemon]:
+    """Generate a structured team from a Smogon statistics format.
+
+    The returned list can be inspected or modified before being converted to a
+    packed team with :meth:`Teambuilder.join_team`. Use
+    :meth:`SmogonStatsTeambuilder.from_format` when the builder itself should be
+    reused or passed to a :class:`~poke_env.player.Player`.
+    """
+    builder = SmogonStatsTeambuilder.from_format(
+        battle_format,
+        month=month,
+        cutoff=cutoff,
+        timeout=timeout,
+        cache_dir=cache_dir,
+        refresh=refresh,
+        team_strategy=team_strategy,
+        pokemon_strategy=pokemon_strategy,
+        rng=rng,
+    )
+    return builder._build_team()
+
+
+def complete_team(
+    partial_team: Sequence[TeambuilderPokemon],
+    battle_format: str,
+    *,
+    month: str = "latest",
+    cutoff: int = 0,
+    timeout: float = 30,
+    cache_dir: Optional[Union[str, Path]] = ".poke_env_stats_cache",
+    refresh: bool = False,
+    team_strategy: Strategy = "greedy",
+    pokemon_strategy: Strategy = "greedy",
+    rng: Optional[Random] = None,
+) -> list[TeambuilderPokemon]:
+    """Complete a partial team using a Smogon statistics format.
+
+    ``partial_team`` should contain :class:`TeambuilderPokemon` objects, for
+    example from :meth:`Teambuilder.parse_showdown_team` or
+    :meth:`Teambuilder.parse_packed_team`. The returned list is independent of the
+    input and can be packed with :meth:`Teambuilder.join_team`.
+    """
+    builder = SmogonStatsTeambuilder.from_format(
+        battle_format,
+        partial_team,
+        month=month,
+        cutoff=cutoff,
+        timeout=timeout,
+        cache_dir=cache_dir,
+        refresh=refresh,
+        team_strategy=team_strategy,
+        pokemon_strategy=pokemon_strategy,
+        rng=rng,
+    )
+    return builder._build_team()

--- a/src/poke_env/teambuilder/smogon_stats_teambuilder.py
+++ b/src/poke_env/teambuilder/smogon_stats_teambuilder.py
@@ -1,0 +1,163 @@
+"""Teambuilders backed by Smogon usage statistics."""
+
+from copy import deepcopy
+from math import exp
+from random import Random
+from typing import Literal, Mapping, Optional, Sequence, TypeVar
+
+from poke_env.data.normalize import to_id_str
+from poke_env.data.smogon import PokemonUsageStats, SmogonStats
+from poke_env.teambuilder.teambuilder import Teambuilder
+from poke_env.teambuilder.teambuilder_pokemon import TeambuilderPokemon
+
+Strategy = Literal["greedy", "sample"]
+_Choice = TypeVar("_Choice")
+
+
+class SmogonStatsTeambuilder(Teambuilder):
+    """Complete teams using one explicit Smogon usage-statistics snapshot.
+
+    The snapshot supplies marginal set frequencies, so fields of a Pokemon's set
+    are selected independently.  Species selection starts from overall usage and
+    multiplies it by the exponential of the selected team's teammate scores. This
+    is a useful association heuristic, not a calibrated joint team distribution.
+
+    :param stats: Statistics snapshot used for every completion.
+    :param team: Partially specified Pokemon to retain and complete.
+    :param strategy: ``"greedy"`` selects the most likely values; ``"sample"``
+        draws from the corresponding weighted distributions.
+    :param rng: Source of randomness for ``"sample"``. Supplying a seeded
+        :class:`random.Random` makes generated teams reproducible.
+    """
+
+    def __init__(
+        self,
+        stats: SmogonStats,
+        team: Sequence[TeambuilderPokemon] = (),
+        *,
+        strategy: Strategy = "greedy",
+        rng: Optional[Random] = None,
+    ):
+        if strategy not in ("greedy", "sample"):
+            raise ValueError("strategy must be 'greedy' or 'sample'")
+        if len(team) > 6:
+            raise ValueError("team cannot contain more than six Pokemon")
+        if any(not pokemon.species for pokemon in team):
+            raise ValueError("each partially specified Pokemon must have a species")
+
+        self.stats = stats
+        self._team = tuple(deepcopy(pokemon) for pokemon in team)
+        self.strategy = strategy
+        self.rng = rng or Random()
+
+        known_species = [
+            pokemon.species for pokemon in self._team if pokemon.species is not None
+        ]
+        if len({to_id_str(species) for species in known_species}) != len(known_species):
+            raise ValueError("team cannot contain duplicate species")
+        for species in known_species:
+            if self.stats.get(species) is None:
+                raise ValueError(
+                    f"species is not present in the statistics snapshot: {species}"
+                )
+        for pokemon in self._team:
+            if len(pokemon.moves) > 4:
+                raise ValueError(
+                    f"{pokemon.species} has more than four specified moves"
+                )
+            if len(set(map(to_id_str, pokemon.moves))) != len(pokemon.moves):
+                raise ValueError(f"{pokemon.species} has duplicate specified moves")
+
+    def yield_team(self) -> str:
+        """Return a packed completed team."""
+        team = [deepcopy(pokemon) for pokemon in self._team]
+        selected_stats = [self._usage_for(pokemon) for pokemon in team]
+
+        while len(team) < 6:
+            pokemon_stats = self._select_species(selected_stats)
+            team.append(TeambuilderPokemon(species=pokemon_stats.name))
+            selected_stats.append(pokemon_stats)
+
+        for pokemon in team:
+            self._complete_pokemon(pokemon, self._usage_for(pokemon))
+        return self.join_team(team)
+
+    def _usage_for(self, pokemon: TeambuilderPokemon) -> PokemonUsageStats:
+        assert pokemon.species is not None
+        return self.stats[pokemon.species]
+
+    def _select_species(
+        self, selected_stats: Sequence[PokemonUsageStats]
+    ) -> PokemonUsageStats:
+        selected_ids = {pokemon.id for pokemon in selected_stats}
+        candidates = {
+            pokemon.id: pokemon
+            for pokemon in self.stats.pokemon.values()
+            if pokemon.id not in selected_ids and pokemon.usage > 0
+        }
+        weights = {
+            pokemon_id: pokemon.usage
+            * exp(
+                sum(
+                    selected.teammate_scores.get(pokemon_id, 0.0)
+                    for selected in selected_stats
+                )
+            )
+            for pokemon_id, pokemon in candidates.items()
+        }
+        return candidates[self._choose(weights, "available Pokemon")]
+
+    def _complete_pokemon(
+        self, pokemon: TeambuilderPokemon, usage: PokemonUsageStats
+    ) -> None:
+        if pokemon.ability is None:
+            pokemon.ability = self._choose(usage.abilities, "ability")
+        if pokemon.item is None and usage.items:
+            pokemon.item = self._choose(usage.items, "item")
+        if pokemon.nature is None or pokemon.evs is None:
+            spread = self._choose(usage.spreads, "spread")
+            if pokemon.nature is None:
+                pokemon.nature = spread.nature
+            if pokemon.evs is None:
+                pokemon.evs = list(spread.evs)
+        if len(pokemon.moves) < 4:
+            pokemon.moves.extend(self._choose_moves(usage.moves, pokemon.moves))
+        if pokemon.tera_type is None and usage.tera_types:
+            pokemon.tera_type = self._choose(usage.tera_types, "Tera type")
+
+    def _choose_moves(
+        self, moves: Mapping[str, float], known_moves: Sequence[str]
+    ) -> list[str]:
+        remaining = {
+            move: weight
+            for move, weight in moves.items()
+            if move not in {to_id_str(move) for move in known_moves}
+        }
+        needed = 4 - len(known_moves)
+        if len(remaining) < needed:
+            raise ValueError("statistics snapshot has fewer than four moves")
+        selected = []
+        for _ in range(needed):
+            move = self._choose(remaining, "move")
+            selected.append(move)
+            del remaining[move]
+        return selected
+
+    def _choose(self, weights: Mapping[_Choice, float], description: str) -> _Choice:
+        ordered = sorted(weights, key=str)
+        if not ordered:
+            raise ValueError(f"statistics snapshot has no {description} values")
+        if self.strategy == "greedy":
+            return max(ordered, key=lambda value: weights[value])
+
+        total = sum(weights[value] for value in ordered)
+        if total <= 0:
+            raise ValueError(
+                f"statistics snapshot has no positive {description} weights"
+            )
+        threshold = self.rng.random() * total
+        for value in ordered:
+            threshold -= weights[value]
+            if threshold <= 0:
+                return value
+        return ordered[-1]

--- a/src/poke_env/teambuilder/smogon_stats_teambuilder.py
+++ b/src/poke_env/teambuilder/smogon_stats_teambuilder.py
@@ -1,7 +1,7 @@
 """Teambuilders backed by Smogon usage statistics."""
 
 from copy import deepcopy
-from math import exp
+from math import prod
 from random import Random
 from typing import Literal, Mapping, Optional, Sequence, TypeVar
 
@@ -19,8 +19,10 @@ class SmogonStatsTeambuilder(Teambuilder):
 
     The snapshot supplies marginal set frequencies, so fields of a Pokemon's set
     are selected independently.  Species selection starts from overall usage and
-    multiplies it by the exponential of the selected team's teammate scores. This
-    is a useful association heuristic, not a calibrated joint team distribution.
+    then uses the geometric mean of the selected Pokemon's teammate distributions.
+    Non-positive teammate scores are ignored when forming these distributions.
+    This is a useful association heuristic, not a calibrated joint team
+    distribution.
 
     :param stats: Statistics snapshot used for every completion.
     :param team: Partially specified Pokemon to retain and complete.
@@ -95,16 +97,40 @@ class SmogonStatsTeambuilder(Teambuilder):
             for pokemon in self.stats.pokemon.values()
             if pokemon.id not in selected_ids and pokemon.usage > 0
         }
-        weights = {
-            pokemon_id: pokemon.usage
-            * exp(
-                sum(
-                    selected.teammate_scores.get(pokemon_id, 0.0)
-                    for selected in selected_stats
+        if not selected_stats:
+            weights = {
+                pokemon_id: pokemon.usage for pokemon_id, pokemon in candidates.items()
+            }
+        else:
+            teammate_distributions = []
+            for selected in selected_stats:
+                positive_scores = {
+                    pokemon_id: max(selected.teammate_scores.get(pokemon_id, 0.0), 0.0)
+                    for pokemon_id in candidates
+                }
+                total = sum(positive_scores.values())
+                if total <= 0:
+                    weights = {
+                        pokemon_id: pokemon.usage
+                        for pokemon_id, pokemon in candidates.items()
+                    }
+                    break
+                teammate_distributions.append(
+                    {
+                        pokemon_id: score / total
+                        for pokemon_id, score in positive_scores.items()
+                    }
                 )
-            )
-            for pokemon_id, pokemon in candidates.items()
-        }
+            else:
+                weights = {
+                    pokemon_id: prod(
+                        distribution[pokemon_id]
+                        for distribution in teammate_distributions
+                    )
+                    ** (1 / len(teammate_distributions))
+                    for pokemon_id in candidates
+                }
+
         return candidates[self._choose(weights, "available Pokemon")]
 
     def _complete_pokemon(

--- a/src/poke_env/teambuilder/smogon_stats_teambuilder.py
+++ b/src/poke_env/teambuilder/smogon_stats_teambuilder.py
@@ -20,15 +20,19 @@ class SmogonStatsTeambuilder(Teambuilder):
     The snapshot supplies marginal set frequencies, so fields of a Pokemon's set
     are selected independently.  Species selection starts from overall usage and
     then uses the geometric mean of the selected Pokemon's teammate distributions.
-    Non-positive teammate scores are ignored when forming these distributions.
-    This is a useful association heuristic, not a calibrated joint team
-    distribution.
+    Negative or zero teammate scores do not contribute to the partner
+    distribution.  The teammate data describes pairs, so completions use pairwise
+    signals rather than attempting to reproduce the full distribution of teams.
 
     :param stats: Statistics snapshot used for every completion.
     :param team: Partially specified Pokemon to retain and complete.
-    :param strategy: ``"greedy"`` selects the most likely values; ``"sample"``
-        draws from the corresponding weighted distributions.
-    :param rng: Source of randomness for ``"sample"``. Supplying a seeded
+    :param team_strategy: ``"greedy"`` selects the most likely species at each
+        step; ``"sample"`` draws species from the corresponding distributions.
+    :param pokemon_strategy: ``"greedy"`` selects the most likely ability, item,
+        spread, move, and Tera type; ``"sample"`` draws each value from its
+        marginal distribution. If a snapshot reports fewer than four moves, all
+        reported moves are used.
+    :param rng: Source of randomness for sampled choices. Supplying a seeded
         :class:`random.Random` makes generated teams reproducible.
     """
 
@@ -37,11 +41,14 @@ class SmogonStatsTeambuilder(Teambuilder):
         stats: SmogonStats,
         team: Sequence[TeambuilderPokemon] = (),
         *,
-        strategy: Strategy = "greedy",
+        team_strategy: Strategy = "greedy",
+        pokemon_strategy: Strategy = "greedy",
         rng: Optional[Random] = None,
     ):
-        if strategy not in ("greedy", "sample"):
-            raise ValueError("strategy must be 'greedy' or 'sample'")
+        if team_strategy not in ("greedy", "sample"):
+            raise ValueError("team_strategy must be 'greedy' or 'sample'")
+        if pokemon_strategy not in ("greedy", "sample"):
+            raise ValueError("pokemon_strategy must be 'greedy' or 'sample'")
         if len(team) > 6:
             raise ValueError("team cannot contain more than six Pokemon")
         if any(not pokemon.species for pokemon in team):
@@ -49,7 +56,8 @@ class SmogonStatsTeambuilder(Teambuilder):
 
         self.stats = stats
         self._team = tuple(deepcopy(pokemon) for pokemon in team)
-        self.strategy = strategy
+        self.team_strategy = team_strategy
+        self.pokemon_strategy = pokemon_strategy
         self.rng = rng or Random()
 
         known_species = [
@@ -131,17 +139,21 @@ class SmogonStatsTeambuilder(Teambuilder):
                     for pokemon_id in candidates
                 }
 
-        return candidates[self._choose(weights, "available Pokemon")]
+        return candidates[
+            self._choose(weights, "available Pokemon", self.team_strategy)
+        ]
 
     def _complete_pokemon(
         self, pokemon: TeambuilderPokemon, usage: PokemonUsageStats
     ) -> None:
         if pokemon.ability is None:
-            pokemon.ability = self._choose(usage.abilities, "ability")
+            pokemon.ability = self._choose(
+                usage.abilities, "ability", self.pokemon_strategy
+            )
         if pokemon.item is None and usage.items:
-            pokemon.item = self._choose(usage.items, "item")
+            pokemon.item = self._choose(usage.items, "item", self.pokemon_strategy)
         if pokemon.nature is None or pokemon.evs is None:
-            spread = self._choose(usage.spreads, "spread")
+            spread = self._choose(usage.spreads, "spread", self.pokemon_strategy)
             if pokemon.nature is None:
                 pokemon.nature = spread.nature
             if pokemon.evs is None:
@@ -149,7 +161,9 @@ class SmogonStatsTeambuilder(Teambuilder):
         if len(pokemon.moves) < 4:
             pokemon.moves.extend(self._choose_moves(usage.moves, pokemon.moves))
         if pokemon.tera_type is None and usage.tera_types:
-            pokemon.tera_type = self._choose(usage.tera_types, "Tera type")
+            pokemon.tera_type = self._choose(
+                usage.tera_types, "Tera type", self.pokemon_strategy
+            )
 
     def _choose_moves(
         self, moves: Mapping[str, float], known_moves: Sequence[str]
@@ -159,21 +173,21 @@ class SmogonStatsTeambuilder(Teambuilder):
             for move, weight in moves.items()
             if move not in {to_id_str(move) for move in known_moves}
         }
-        needed = 4 - len(known_moves)
-        if len(remaining) < needed:
-            raise ValueError("statistics snapshot has fewer than four moves")
+        needed = min(4 - len(known_moves), len(remaining))
         selected = []
         for _ in range(needed):
-            move = self._choose(remaining, "move")
+            move = self._choose(remaining, "move", self.pokemon_strategy)
             selected.append(move)
             del remaining[move]
         return selected
 
-    def _choose(self, weights: Mapping[_Choice, float], description: str) -> _Choice:
+    def _choose(
+        self, weights: Mapping[_Choice, float], description: str, strategy: Strategy
+    ) -> _Choice:
         ordered = sorted(weights, key=str)
         if not ordered:
             raise ValueError(f"statistics snapshot has no {description} values")
-        if self.strategy == "greedy":
+        if strategy == "greedy":
             return max(ordered, key=lambda value: weights[value])
 
         total = sum(weights[value] for value in ordered)

--- a/unit_tests/teambuilder/test_smogon_stats_teambuilder.py
+++ b/unit_tests/teambuilder/test_smogon_stats_teambuilder.py
@@ -4,7 +4,12 @@ import orjson
 import pytest
 
 from poke_env.data.smogon import SmogonStats
-from poke_env.teambuilder import SmogonStatsTeambuilder, TeambuilderPokemon
+from poke_env.teambuilder import (
+    SmogonStatsTeambuilder,
+    TeambuilderPokemon,
+    complete_team,
+    generate_team,
+)
 from poke_env.teambuilder.teambuilder import Teambuilder
 
 
@@ -162,6 +167,62 @@ def test_pokemon_with_fewer_than_four_reported_moves_is_completed(smogon_stats):
     builder = SmogonStatsTeambuilder(smogon_stats)
 
     assert builder._choose_moves({"transform": 1.0}, []) == ["transform"]
+
+
+def test_from_format_fetches_snapshot(monkeypatch, smogon_stats):
+    calls = {}
+
+    def fetch(cls, battle_format, **kwargs):
+        calls["battle_format"] = battle_format
+        calls["kwargs"] = kwargs
+        return smogon_stats
+
+    monkeypatch.setattr(SmogonStats, "fetch", classmethod(fetch))
+
+    builder = SmogonStatsTeambuilder.from_format(
+        "gen9ou",
+        month="2026-06",
+        cutoff=1695,
+        timeout=12,
+        cache_dir=None,
+        refresh=True,
+        team_strategy="sample",
+        pokemon_strategy="greedy",
+        rng=Random(7),
+    )
+
+    assert calls == {
+        "battle_format": "gen9ou",
+        "kwargs": {
+            "month": "2026-06",
+            "cutoff": 1695,
+            "timeout": 12,
+            "cache_dir": None,
+            "refresh": True,
+        },
+    }
+    assert builder.stats is smogon_stats
+    assert builder.team_strategy == "sample"
+    assert builder.pokemon_strategy == "greedy"
+
+
+def test_convenience_helpers_return_structured_teams(monkeypatch, smogon_stats):
+    monkeypatch.setattr(
+        SmogonStats,
+        "fetch",
+        classmethod(lambda cls, battle_format, **kwargs: smogon_stats),
+    )
+
+    generated = generate_team("gen9ou", rng=Random(7))
+    assert len(generated) == 6
+    assert all(isinstance(pokemon, TeambuilderPokemon) for pokemon in generated)
+
+    partial = [TeambuilderPokemon(species="Alpha", moves=["Observed Move"])]
+    completed = complete_team(partial, "gen9ou", rng=Random(7))
+
+    assert len(completed) == 6
+    assert completed[0].moves[0] == "Observed Move"
+    assert partial[0].moves == ["Observed Move"]
 
 
 @pytest.mark.parametrize(

--- a/unit_tests/teambuilder/test_smogon_stats_teambuilder.py
+++ b/unit_tests/teambuilder/test_smogon_stats_teambuilder.py
@@ -67,6 +67,43 @@ def test_greedy_builder_completes_observed_set_and_team(smogon_stats):
     assert team[0].tera_type == "steel"
 
 
+def test_species_selection_uses_geometric_mean_of_teammates():
+    def pokemon(usage, teammates):
+        return {
+            "Raw count": 100,
+            "Abilities": {"ability": 10},
+            "Items": {},
+            "Spreads": {"Jolly:0/252/0/0/0/252": 10},
+            "Moves": {"moveone": 10, "movetwo": 10, "movethree": 10, "movefour": 10},
+            "Tera Types": {},
+            "Teammates": teammates,
+            "usage": usage,
+        }
+
+    stats = SmogonStats.from_json(
+        orjson.dumps(
+            {
+                "info": {
+                    "metagame": "gen9ou",
+                    "cutoff": 1695,
+                    "number of battles": 1000,
+                },
+                "data": {
+                    "Alpha": pokemon(0.4, {"Gamma": 9, "Delta": 4}),
+                    "Beta": pokemon(0.3, {"Gamma": 1, "Delta": 4}),
+                    "Gamma": pokemon(0.2, {}),
+                    "Delta": pokemon(0.1, {}),
+                },
+            }
+        ),
+        month="2026-06",
+    )
+
+    builder = SmogonStatsTeambuilder(stats)
+
+    assert builder._select_species([stats["Alpha"], stats["Beta"]]).id == "delta"
+
+
 def test_sample_builder_is_seeded_and_preserves_observed_values(smogon_stats):
     team = [TeambuilderPokemon(species="Alpha", item="Kept Item", moves=["Move One"])]
     first = SmogonStatsTeambuilder(smogon_stats, team, strategy="sample", rng=Random(7))

--- a/unit_tests/teambuilder/test_smogon_stats_teambuilder.py
+++ b/unit_tests/teambuilder/test_smogon_stats_teambuilder.py
@@ -1,0 +1,101 @@
+from random import Random
+
+import orjson
+import pytest
+
+from poke_env.data.smogon import SmogonStats
+from poke_env.teambuilder import SmogonStatsTeambuilder, TeambuilderPokemon
+from poke_env.teambuilder.teambuilder import Teambuilder
+
+
+@pytest.fixture
+def smogon_stats():
+    def pokemon(usage, teammates):
+        return {
+            "Raw count": 100,
+            "Abilities": {"abilityone": 8, "abilitytwo": 2},
+            "Items": {"itemone": 7, "itemtwo": 3},
+            "Spreads": {"Jolly:0/252/4/0/0/252": 7, "Impish:252/0/252/0/4/0": 3},
+            "Moves": {
+                "moveone": 10,
+                "movetwo": 9,
+                "movethree": 8,
+                "movefour": 7,
+                "movefive": 6,
+            },
+            "Tera Types": {"Steel": 8, "Water": 2},
+            "Teammates": teammates,
+            "usage": usage,
+        }
+
+    return SmogonStats.from_json(
+        orjson.dumps(
+            {
+                "info": {
+                    "metagame": "gen9ou",
+                    "cutoff": 1695,
+                    "number of battles": 1000,
+                },
+                "data": {
+                    "Alpha": pokemon(0.4, {"Beta": 8, "Gamma": -8}),
+                    "Beta": pokemon(0.3, {"Alpha": 0.1}),
+                    "Gamma": pokemon(0.5, {"Alpha": 0.1}),
+                    "Delta": pokemon(0.2, {}),
+                    "Epsilon": pokemon(0.1, {}),
+                    "Zeta": pokemon(0.05, {}),
+                },
+            }
+        ),
+        month="2026-06",
+    )
+
+
+def test_greedy_builder_completes_observed_set_and_team(smogon_stats):
+    builder = SmogonStatsTeambuilder(
+        smogon_stats, [TeambuilderPokemon(species="Alpha", moves=["Observed Move"])]
+    )
+
+    team = Teambuilder.parse_packed_team(builder.yield_team())
+
+    assert [pokemon.species for pokemon in team[:2]] == ["alpha", "beta"]
+    assert len(team) == len({pokemon.species for pokemon in team}) == 6
+    assert team[0].moves == ["observedmove", "moveone", "movetwo", "movethree"]
+    assert team[0].ability == "abilityone"
+    assert team[0].item == "itemone"
+    assert team[0].nature == "Jolly"
+    assert team[0].evs == [0, 252, 4, 0, 0, 252]
+    assert team[0].tera_type == "steel"
+
+
+def test_sample_builder_is_seeded_and_preserves_observed_values(smogon_stats):
+    team = [TeambuilderPokemon(species="Alpha", item="Kept Item", moves=["Move One"])]
+    first = SmogonStatsTeambuilder(smogon_stats, team, strategy="sample", rng=Random(7))
+    second = SmogonStatsTeambuilder(
+        smogon_stats, team, strategy="sample", rng=Random(7)
+    )
+
+    first_team = Teambuilder.parse_packed_team(first.yield_team())
+    second_team = Teambuilder.parse_packed_team(second.yield_team())
+    assert [pokemon.packed for pokemon in first_team] == [
+        pokemon.packed for pokemon in second_team
+    ]
+    assert first_team[0].item == "keptitem"
+    assert first_team[0].moves[0] == "moveone"
+    assert len(first_team[0].moves) == len(set(first_team[0].moves)) == 4
+
+
+@pytest.mark.parametrize(
+    "team, message",
+    [
+        ([TeambuilderPokemon(species="Missing")], "not present"),
+        (
+            [TeambuilderPokemon(species="Alpha"), TeambuilderPokemon(species="alpha")],
+            "duplicate",
+        ),
+        ([TeambuilderPokemon(species="Alpha", moves=["a", "a"])], "duplicate"),
+    ],
+)
+def test_builder_rejects_invalid_partial_teams(smogon_stats, team, message):
+    with pytest.raises(ValueError, match=message):
+        builder = SmogonStatsTeambuilder(smogon_stats, team)
+        builder.yield_team()

--- a/unit_tests/teambuilder/test_smogon_stats_teambuilder.py
+++ b/unit_tests/teambuilder/test_smogon_stats_teambuilder.py
@@ -25,6 +25,7 @@ def smogon_stats():
             },
             "Tera Types": {"Steel": 8, "Water": 2},
             "Teammates": teammates,
+            "Checks and Counters": {},
             "usage": usage,
         }
 
@@ -77,6 +78,7 @@ def test_species_selection_uses_geometric_mean_of_teammates():
             "Moves": {"moveone": 10, "movetwo": 10, "movethree": 10, "movefour": 10},
             "Tera Types": {},
             "Teammates": teammates,
+            "Checks and Counters": {},
             "usage": usage,
         }
 

--- a/unit_tests/teambuilder/test_smogon_stats_teambuilder.py
+++ b/unit_tests/teambuilder/test_smogon_stats_teambuilder.py
@@ -108,9 +108,19 @@ def test_species_selection_uses_geometric_mean_of_teammates():
 
 def test_sample_builder_is_seeded_and_preserves_observed_values(smogon_stats):
     team = [TeambuilderPokemon(species="Alpha", item="Kept Item", moves=["Move One"])]
-    first = SmogonStatsTeambuilder(smogon_stats, team, strategy="sample", rng=Random(7))
+    first = SmogonStatsTeambuilder(
+        smogon_stats,
+        team,
+        team_strategy="sample",
+        pokemon_strategy="sample",
+        rng=Random(7),
+    )
     second = SmogonStatsTeambuilder(
-        smogon_stats, team, strategy="sample", rng=Random(7)
+        smogon_stats,
+        team,
+        team_strategy="sample",
+        pokemon_strategy="sample",
+        rng=Random(7),
     )
 
     first_team = Teambuilder.parse_packed_team(first.yield_team())
@@ -121,6 +131,37 @@ def test_sample_builder_is_seeded_and_preserves_observed_values(smogon_stats):
     assert first_team[0].item == "keptitem"
     assert first_team[0].moves[0] == "moveone"
     assert len(first_team[0].moves) == len(set(first_team[0].moves)) == 4
+
+
+def test_team_and_pokemon_strategies_are_independent(smogon_stats):
+    team = [TeambuilderPokemon(species="Alpha")]
+    greedy_team = SmogonStatsTeambuilder(
+        smogon_stats,
+        team,
+        team_strategy="greedy",
+        pokemon_strategy="sample",
+        rng=Random(7),
+    )
+    sample_team = SmogonStatsTeambuilder(
+        smogon_stats,
+        team,
+        team_strategy="sample",
+        pokemon_strategy="greedy",
+        rng=Random(7),
+    )
+
+    assert greedy_team.team_strategy == "greedy"
+    assert greedy_team.pokemon_strategy == "sample"
+    assert sample_team.team_strategy == "sample"
+    assert sample_team.pokemon_strategy == "greedy"
+    assert len(Teambuilder.parse_packed_team(greedy_team.yield_team())) == 6
+    assert len(Teambuilder.parse_packed_team(sample_team.yield_team())) == 6
+
+
+def test_pokemon_with_fewer_than_four_reported_moves_is_completed(smogon_stats):
+    builder = SmogonStatsTeambuilder(smogon_stats)
+
+    assert builder._choose_moves({"transform": 1.0}, []) == ["transform"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Adds a SmogonStats-backed teambuilder so callers can complete partial teams with either most-likely or sampled usage-statistics values.

The new `SmogonStatsTeambuilder` preserves observed set fields, completes missing build details and moves, fills empty slots from usage and teammate-affinity scores, and exposes seeded sampling for reproducible team generation. It deliberately uses independent marginal set fields, since the current snapshots do not provide joint set distributions.

Validation:

- `uv run pytest` (304 passed)
- `uv run black --check src/poke_env/teambuilder/smogon_stats_teambuilder.py unit_tests/teambuilder/test_smogon_stats_teambuilder.py`
- `uv run isort --check-only src/poke_env/teambuilder/smogon_stats_teambuilder.py unit_tests/teambuilder/test_smogon_stats_teambuilder.py`