### PR TITLE
Fix Gymnasium action masks and pin dependency

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@v7
         with:
-          file: coverage.xml
+          files: coverage.xml
 
       - name: Build package
         run: uv build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-    "gymnasium>=1.0.0",
+    "gymnasium==1.3.0",
     "numpy>=2.0.2",
     "orjson>=3.10.15",
     "pettingzoo>=1.24.3",

--- a/src/poke_env/environment/env.py
+++ b/src/poke_env/environment/env.py
@@ -324,7 +324,7 @@ class PokeEnv(ParallelEnv[str, Dict[str, Any], ActionType]):
                             low=0,
                             high=1,
                             shape=(flatdim(self.action_spaces[agent]),),
-                            dtype=np.int64,
+                            dtype=np.int8,
                         ),
                     }
                 )
@@ -447,11 +447,11 @@ class PokeEnv(ParallelEnv[str, Dict[str, Any], ActionType]):
         observations = {
             self.agents[0]: {
                 "observation": self.embed_battle(battle1),
-                "action_mask": np.array(self.get_action_mask(battle1)),
+                "action_mask": np.array(self.get_action_mask(battle1), dtype=np.int8),
             },
             self.agents[1]: {
                 "observation": self.embed_battle(battle2),
-                "action_mask": np.array(self.get_action_mask(battle2)),
+                "action_mask": np.array(self.get_action_mask(battle2), dtype=np.int8),
             },
         }
         reward = {
@@ -505,11 +505,15 @@ class PokeEnv(ParallelEnv[str, Dict[str, Any], ActionType]):
         observations = {
             self.agents[0]: {
                 "observation": self.embed_battle(self.battle1),
-                "action_mask": np.array(self.get_action_mask(self.battle1)),
+                "action_mask": np.array(
+                    self.get_action_mask(self.battle1), dtype=np.int8
+                ),
             },
             self.agents[1]: {
                 "observation": self.embed_battle(self.battle2),
-                "action_mask": np.array(self.get_action_mask(self.battle2)),
+                "action_mask": np.array(
+                    self.get_action_mask(self.battle2), dtype=np.int8
+                ),
             },
         }
         return observations, self.get_additional_info()

--- a/unit_tests/player/test_env.py
+++ b/unit_tests/player/test_env.py
@@ -138,6 +138,8 @@ def test_reset_step_close():
     np.testing.assert_array_equal(
         obs[env.agents[1]]["observation"], np.array([0, 1, 2])
     )
+    for agent in env.agents:
+        assert obs[agent]["action_mask"].dtype == np.int8
     assert add_info == {env.agents[0]: {}, env.agents[1]: {}}
 
     # --- Part 2: Test step() ---
@@ -164,6 +166,8 @@ def test_reset_step_close():
     np.testing.assert_array_equal(
         obs_step[env.agents[1]]["observation"], np.array([0, 1, 2])
     )
+    for agent in env.agents:
+        assert obs_step[agent]["action_mask"].dtype == np.int8
     # Check that rewards match CustomEnv.calc_reward.
     assert rew[env.agents[0]] == 69.42
     assert rew[env.agents[1]] == 69.42


### PR DESCRIPTION
Fix CI failures caused by Gymnasium/PettingZoo action-mask validation, pin Gymnasium for controlled bugbot updates, and correct the Codecov coverage input.

The environment now emits action masks as `np.int8`, matching Gymnasium's masked sampling contract. Gymnasium is pinned to `1.3.0` so future upgrades arrive as explicit bugbot updates, and the Codecov workflow uses `files` instead of the removed `file` input.

Validation:

- `uv run pytest -x --cov=src/poke_env unit_tests/` — 299 passed
- `uv run --no-sync pytest -x integration_tests/` — 34 passed
- `uv run --no-sync black --check src/poke_env/environment/env.py unit_tests/player/test_env.py`
- `uv run --no-sync flake8 src/poke_env/environment/env.py unit_tests/player/test_env.py`
- `uv run --no-sync mypy src`
- `uv build`

This PR intentionally contains three commits: the action-mask fix, the Gymnasium pin, and the Codecov input fix.