### PR TITLE
Simplify learnset generation and caching

### DIFF
--- a/src/poke_env/battle/abstract_battle.py
+++ b/src/poke_env/battle/abstract_battle.py
@@ -314,18 +314,12 @@ class AbstractBattle(ABC):
             )
 
         if request:
-            team[identifier] = Pokemon(
-                request_pokemon=request, name=name, gen=self.gen, format=self.format
-            )
+            team[identifier] = Pokemon(request_pokemon=request, name=name, gen=self.gen)
         elif details:
-            team[identifier] = Pokemon(
-                details=details, name=name, gen=self.gen, format=self.format
-            )
+            team[identifier] = Pokemon(details=details, name=name, gen=self.gen)
         else:
             species = identifier[4:]
-            team[identifier] = Pokemon(
-                species=species, name=name, gen=self.gen, format=self.format
-            )
+            team[identifier] = Pokemon(species=species, name=name, gen=self.gen)
 
         return team[identifier]
 
@@ -1232,7 +1226,7 @@ class AbstractBattle(ABC):
 
     def _register_teampreview_pokemon(self, player: str, details: str):
         if player != self._player_role:
-            mon = Pokemon(details=details, gen=self.gen, format=self.format)
+            mon = Pokemon(details=details, gen=self.gen)
             self._teampreview_opponent_team.append(mon)
 
     def side_end(self, side: str, condition_str: str):

--- a/src/poke_env/battle/pokemon.py
+++ b/src/poke_env/battle/pokemon.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional, Set, Union
+from typing import Any, Dict, FrozenSet, List, Optional, Union
 
 from poke_env.battle.effect import Effect
 from poke_env.battle.field import Field
@@ -35,7 +35,6 @@ class Pokemon:
         "_last_details",
         "_last_request",
         "_learnset",
-        "_learnset_format",
         "_level",
         "_max_hp",
         "_moves",
@@ -63,9 +62,6 @@ class Pokemon:
         "_weightkg",
     )
 
-    # The formats that have a different learnset
-    _ALL_MOVES_FORMATS = ["hackmons", "stabmons", "sketchmons"]
-
     def __init__(
         self,
         gen: int,
@@ -75,7 +71,6 @@ class Pokemon:
         request_pokemon: Optional[Dict[str, Any]] = None,
         details: Optional[str] = None,
         teambuilder: Optional[TeambuilderPokemon] = None,
-        format: Optional[str] = None,
     ):
         # Species related attributes
         self._base_stats: Dict[str, int]
@@ -85,7 +80,7 @@ class Pokemon:
         self._type_1: PokemonType
         self._type_2: Optional[PokemonType] = None
         self._weightkg: int
-        self._learnset: Set[str] = set()
+        self._learnset: FrozenSet[str] = frozenset()
 
         # Individual related attributes
         self._ability: Optional[str] = None
@@ -100,9 +95,6 @@ class Pokemon:
         self._evs: list[int] | None = None
         self._ivs: list[int] | None = None
         self._nature: str | None = None
-        self._learnset_format: bool = (
-            not any(f in (format or "") for f in self._ALL_MOVES_FORMATS) and gen >= 3
-        )
 
         # Battle related attributes
         self._gen = gen
@@ -1142,10 +1134,10 @@ class Pokemon:
         return self._level
 
     @property
-    def learnset(self) -> Set[str]:
+    def learnset(self) -> FrozenSet[str]:
         """
         :return: The set of moves this pokemon can learn.
-        :rtype: Set[str]
+        :rtype: FrozenSet[str]
         """
         return self._learnset
 

--- a/src/poke_env/data/gen_data.py
+++ b/src/poke_env/data/gen_data.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import os
-from typing import Any, Dict, List, Optional, Set, Union
+from typing import Any, Dict, FrozenSet, Optional, Set, Union
 
 import orjson
 
@@ -17,6 +17,7 @@ class GenData:
         "pokedex",
         "type_chart",
         "learnset",
+        "_learnset_cache",
     )
 
     UNKNOWN_ITEM = "unknown_item"
@@ -32,8 +33,11 @@ class GenData:
         self.natures = self.load_natures()
         self.pokedex = self.load_pokedex(gen)
         self.type_chart = self.load_type_chart(gen)
-        self.raw_learnset = self.load_raw_learnset()
-        self.learnset: Dict[str, Set[str]] = {}
+        self.learnset = self.load_learnset()
+        # Keep the new name as an alias while preserving the public learnset
+        # attribute's original raw-data semantics.
+        self.raw_learnset = self.learnset
+        self._learnset_cache: Dict[str, FrozenSet[str]] = {}
 
     def __deepcopy__(self, memodict: Optional[Dict[int, Any]] = None) -> GenData:
         return self
@@ -48,11 +52,12 @@ class GenData:
         with open(os.path.join(self._static_files_root, "natures.json")) as f:
             return orjson.loads(f.read())
 
-    def load_raw_learnset(
-        self,
-    ) -> Dict[str, Dict[str, Union[int, float, Dict[str, List[str]]]]]:
+    def load_learnset(self) -> Dict[str, Dict[str, Any]]:
         with open(os.path.join(self._static_files_root, "learnset.json")) as f:
             return orjson.loads(f.read())
+
+    def load_raw_learnset(self) -> Dict[str, Dict[str, Any]]:
+        return self.load_learnset()
 
     def load_pokedex(self, gen: int) -> Dict[str, Any]:
         with open(
@@ -135,13 +140,45 @@ class GenData:
         return cls.from_gen(gen)
 
     @classmethod
-    def obtain_learnset(cls, pokemon_species: str, gen: int) -> Set[str]:
+    def obtain_learnset(cls, pokemon_species: str, gen: int) -> FrozenSet[str]:
         gen_data = cls.from_gen(gen)
 
-        if pokemon_species not in gen_data.learnset:
+        if pokemon_species not in gen_data._learnset_cache:
             gen_data.generate_learnset(pokemon_species)
 
-        return gen_data.learnset[pokemon_species]
+        return gen_data._learnset_cache[pokemon_species]
+
+    @staticmethod
+    def _source_generation(source: Any) -> Optional[int]:
+        if isinstance(source, str) and source and source[0].isdigit():
+            return int(source[0])
+        return None
+
+    def _learnset_for_generation(self, species: str, generation: int) -> Set[str]:
+        species_data = self.raw_learnset.get(species, {})
+        learnset = species_data.get("learnset")
+        if not isinstance(learnset, dict):
+            return set()
+
+        available_moves = GenData.from_gen(generation).moves
+        result: Set[str] = set()
+        for move, sources in learnset.items():
+            move_data = available_moves.get(move)
+            if (
+                not isinstance(move_data, dict)
+                or move_data.get("isNonstandard") == "Past"
+                or not isinstance(sources, list)
+            ):
+                continue
+
+            if any(
+                (source_generation := self._source_generation(source)) is not None
+                and source_generation <= generation
+                for source in sources
+            ):
+                result.add(move)
+
+        return result
 
     def generate_learnset(self, pokemon_species: str) -> None:
         """
@@ -159,65 +196,32 @@ class GenData:
             - None: this method updates the learnset in place and does not return anything
         """
         current_gen = self.gen
-        self.learnset[pokemon_species] = set()
+        learnset: Set[str] = set()
 
-        while current_gen >= 3 and not self.learnset[pokemon_species]:
+        while current_gen >= 3 and not learnset:
             dex_entry = self.pokedex[pokemon_species]
 
             # Moveset from the current form
-            if (
-                pokemon_species in self.raw_learnset
-                and "learnset" in self.raw_learnset[pokemon_species]
-            ):
-                learn = self.raw_learnset[pokemon_species]["learnset"]
-                if isinstance(learn, dict):
-                    for move, sources in learn.items():
-                        if any(s.startswith(str(current_gen)) for s in sources):
-                            self.learnset[pokemon_species].add(move)
+            learnset.update(self._learnset_for_generation(pokemon_species, current_gen))
 
             # Moveset from the form without the item
-            if "species" in dex_entry and (
-                "battleOnly" in dex_entry or not self.learnset[pokemon_species]
-            ):
+            if "species" in dex_entry and ("battleOnly" in dex_entry or not learnset):
                 dex_species = to_id_str(dex_entry["species"])
-                if (
-                    dex_species in self.raw_learnset
-                    and "learnset" in self.raw_learnset[dex_species]
-                ):
-                    learn = self.raw_learnset[dex_species]["learnset"]
-                    if isinstance(learn, dict):
-                        for move, sources in learn.items():
-                            if any(s.startswith(str(current_gen)) for s in sources):
-                                self.learnset[pokemon_species].add(move)
+                learnset.update(self._learnset_for_generation(dex_species, current_gen))
 
             # Moveset from the form it comes from
             if "changesFrom" in dex_entry:
                 previous_form = to_id_str(dex_entry["changesFrom"])
-                if (
-                    previous_form in self.raw_learnset
-                    and "learnset" in self.raw_learnset[previous_form]
-                ):
-                    learn = self.raw_learnset[previous_form]["learnset"]
-                    if isinstance(learn, dict):
-                        for move, sources in learn.items():
-                            if any(s.startswith(str(current_gen)) for s in sources):
-                                self.learnset[pokemon_species].add(move)
+                learnset.update(
+                    self._learnset_for_generation(previous_form, current_gen)
+                )
 
             # Moveset from its prevolution line
             prevolution = (
                 to_id_str(dex_entry["prevo"]) if "prevo" in dex_entry else None
             )
             while prevolution:
-
-                if (
-                    prevolution in self.raw_learnset
-                    and "learnset" in self.raw_learnset[prevolution]
-                ):
-                    learn = self.raw_learnset[prevolution]["learnset"]
-                    if isinstance(learn, dict):
-                        for move, sources in learn.items():
-                            if any(s.startswith(str(self.gen)) for s in sources):
-                                self.learnset[pokemon_species].add(move)
+                learnset.update(self._learnset_for_generation(prevolution, current_gen))
 
                 prevo_dex_entry = self.pokedex.get(prevolution, {})
                 prevolution = (
@@ -227,3 +231,5 @@ class GenData:
                 )
 
             current_gen -= 1
+
+        self._learnset_cache[pokemon_species] = frozenset(learnset)

--- a/unit_tests/environment/test_pokemon.py
+++ b/unit_tests/environment/test_pokemon.py
@@ -1,5 +1,7 @@
 from unittest.mock import MagicMock
 
+import pytest
+
 from poke_env.battle import DoubleBattle, Move, Pokemon, PokemonGender, PokemonType
 from poke_env.stats import _raw_hp, _raw_stat
 from poke_env.teambuilder import TeambuilderPokemon
@@ -525,41 +527,29 @@ def test_temporary():
     assert furret.types == [PokemonType.DRAGON]
 
 
-def test_normal_learnset():
-    formats = [
-        "gen9randombattle",
-        "gen9randomdoublesbattle",
-        "gen9ou",
-        "gen9ubers",
-        "gen9anythinggoes",
-        "gen9ru",
-        "gen9vgc2026regi",
-        "gen9freeforallrandombattle",
-    ]
-
-    for format_ in formats:
-        mon = Pokemon(species="bulbasaur", gen=9, format=format_)
-        assert mon._learnset_format
-
-
-def test_different_learnset():
-    formats = [
-        (6, "gen6purehackmons"),
-        (7, "gen7balancedhackmons"),
-        (9, "gen9stabmons"),
-    ]
-
-    for gen, format_ in formats:
-        mon = Pokemon(species="bulbasaur", gen=gen, format=format_)
-        assert not mon._learnset_format
-
-
 def test_breloom_learnset():
     # Breeloom only has spore from Shroomish
 
     for gen in range(3, 8):
         mon = Pokemon(species="breloom", gen=gen)
         assert "spore" in mon.learnset
+
+    assert "spore" in Pokemon(species="breloom", gen=8).learnset
+
+
+def test_learnset_includes_transfer_moves():
+    xatu = Pokemon(species="xatu", gen=7)
+    assert "aircutter" in xatu.learnset
+    assert "hiddenpower" not in Pokemon(species="pikachu", gen=9).learnset
+
+
+def test_learnset_is_immutable_and_cached_separately():
+    first = Pokemon(species="pikachu", gen=9)
+    second = Pokemon(species="pikachu", gen=9)
+
+    assert first.learnset is second.learnset
+    with pytest.raises(AttributeError):
+        first.learnset.add("splash")
 
 
 def test_pikachu_learnset():

--- a/unit_tests/test_data.py
+++ b/unit_tests/test_data.py
@@ -63,6 +63,11 @@ def test_gen_data_from_format():
     assert GenData.from_format("gen9doubleou") == GenData.from_gen(9)
 
 
+def test_learnset_remains_raw_data():
+    learnset = GenData.from_gen(9).learnset["bulbasaur"]["learnset"]
+    assert isinstance(learnset, dict)
+
+
 def test_cant_init_same_gen_twice():
     for gen in range(1, 9):
         GenData.from_gen(gen)


### PR DESCRIPTION
Simplify learnset generation and caching so Pokémon learnsets remain compatible with existing GenData consumers while correctly handling Dexit, transfer moves, and immutable caching.

## Summary

- Preserve the raw `GenData.learnset` mapping and keep generated Pokémon learnsets in a separate cache.
- Include valid prior-generation transfer sources, exclude moves marked `Past`, and use the fallback generation for pre-evolution moves.
- Return immutable learnset values.
- Remove unused Pokémon format plumbing.
- Add regression tests for Dexit inheritance, transfer moves, removed moves, cache immutability, and raw GenData compatibility.

## Validation

- `uv run pytest -q unit_tests --ignore=unit_tests/ps_client/test_ps_client.py` — 316 passed after rebasing onto `origin/master`.
- Black, isort, flake8, mypy, and `git diff --check` passed.