### PR TITLE
Add shared player options for environments

### DIFF
--- a/docs/source/modules/player.rst
+++ b/docs/source/modules/player.rst
@@ -13,6 +13,14 @@ Player
    :undoc-members:
    :show-inheritance:
 
+Player options
+**************
+
+.. automodule:: poke_env.player.player_options
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 Baselines
 *********
 

--- a/src/poke_env/__init__.py
+++ b/src/poke_env/__init__.py
@@ -7,6 +7,7 @@ from poke_env.exceptions import ShowdownException
 from poke_env.player import (
     MaxBasePowerPlayer,
     Player,
+    PlayerOptions,
     RandomPlayer,
     SimpleHeuristicsPlayer,
     cross_evaluate,
@@ -31,6 +32,7 @@ __all__ = [
     "LocalhostServerConfiguration",
     "MaxBasePowerPlayer",
     "Player",
+    "PlayerOptions",
     "RandomPlayer",
     "ServerConfiguration",
     "ShowdownException",

--- a/src/poke_env/environment/doubles_env.py
+++ b/src/poke_env/environment/doubles_env.py
@@ -18,6 +18,7 @@ from poke_env.player.battle_order import (
     SingleBattleOrder,
 )
 from poke_env.player.player import Player
+from poke_env.player.player_options import PlayerOptions
 from poke_env.ps_client import (
     AccountConfiguration,
     LocalhostServerConfiguration,
@@ -49,10 +50,12 @@ class DoublesEnv(PokeEnv[npt.NDArray[np.int64]]):
         choose_on_teampreview: bool = True,
         fake: bool = False,
         strict: bool = True,
+        player_options: Optional[PlayerOptions] = None,
     ):
         super().__init__(
             account_configuration1=account_configuration1,
             account_configuration2=account_configuration2,
+            player_options=player_options,
             avatar=avatar,
             battle_format=battle_format,
             log_level=log_level,
@@ -70,7 +73,7 @@ class DoublesEnv(PokeEnv[npt.NDArray[np.int64]]):
             fake=fake,
             strict=strict,
         )
-        gen = GenData.from_format(battle_format).gen
+        gen = GenData.from_format(self._player_options.battle_format).gen
         action_space_size = DoublesEnv.get_action_space_size(gen)
         self.action_spaces = {
             agent: MultiDiscrete([action_space_size, action_space_size])

--- a/src/poke_env/environment/doubles_env.py
+++ b/src/poke_env/environment/doubles_env.py
@@ -28,6 +28,8 @@ from poke_env.teambuilder import Teambuilder
 
 
 class DoublesEnv(PokeEnv[npt.NDArray[np.int64]]):
+    _default_battle_format = "gen9randomdoublesbattle"
+
     def __init__(
         self,
         account_configuration1: Optional[AccountConfiguration] = None,

--- a/src/poke_env/environment/env.py
+++ b/src/poke_env/environment/env.py
@@ -41,6 +41,8 @@ from poke_env.teambuilder.teambuilder import Teambuilder
 ItemType = TypeVar("ItemType")
 ActionType = TypeVar("ActionType")
 
+_DEFAULT_POKE_ENV_PLAYER_OPTIONS = PlayerOptions(battle_format="gen8randombattle")
+
 
 class _AsyncQueue(Generic[ItemType]):
     queue: asyncio.Queue[ItemType]
@@ -185,6 +187,7 @@ class PokeEnv(ParallelEnv[str, Dict[str, Any], ActionType]):
         *,
         account_configuration1: Optional[AccountConfiguration] = None,
         account_configuration2: Optional[AccountConfiguration] = None,
+        player_options: Optional[PlayerOptions] = None,
         avatar: Optional[int] = None,
         battle_format: str = "gen9randombattle",
         log_level: Optional[int] = None,
@@ -209,6 +212,9 @@ class PokeEnv(ParallelEnv[str, Dict[str, Any], ActionType]):
             automatically generated username with no password. This option must be set
             if the server configuration requires authentication.
         :type account_configuration: AccountConfiguration, optional
+        :param player_options: Shared options used to create both agents. When set,
+            the player-specific keyword arguments must remain at their defaults.
+        :type player_options: PlayerOptions, optional
         :param avatar: Player avatar id. Optional.
         :type avatar: int, optional
         :param battle_format: Name of the battle format this player plays. Defaults to
@@ -267,15 +273,11 @@ class PokeEnv(ParallelEnv[str, Dict[str, Any], ActionType]):
         """
         self.metadata = {"name": "poke-env-v0", "render_modes": ["human"]}
         self.render_mode: str | None = None
-        self._avatar = avatar
-        self._battle_format = battle_format
         self._challenge_timeout = challenge_timeout
         self._choose_on_teampreview = choose_on_teampreview
         self._fake = fake
         self._strict = strict
-        self._loop = asyncio.new_event_loop()
-        Thread(target=self._loop.run_forever, daemon=True).start()
-        self._player_options = PlayerOptions(
+        legacy_player_options = PlayerOptions(
             avatar=avatar,
             battle_format=battle_format,
             log_level=log_level,
@@ -290,6 +292,20 @@ class PokeEnv(ParallelEnv[str, Dict[str, Any], ActionType]):
             ping_timeout=ping_timeout,
             team=team,
         )
+        if (
+            player_options is not None
+            and legacy_player_options != _DEFAULT_POKE_ENV_PLAYER_OPTIONS
+        ):
+            raise TypeError(
+                "player_options cannot be combined with non-default player options"
+            )
+        self._player_options = (
+            player_options if player_options is not None else legacy_player_options
+        )
+        self._avatar = self._player_options.avatar
+        self._battle_format = self._player_options.battle_format
+        self._loop = asyncio.new_event_loop()
+        Thread(target=self._loop.run_forever, daemon=True).start()
         self.agent1 = self._create_agent(account_configuration1)
         self.agent2 = self._create_agent(account_configuration2)
 

--- a/src/poke_env/environment/env.py
+++ b/src/poke_env/environment/env.py
@@ -30,6 +30,7 @@ from poke_env.player.battle_order import (
     _EmptyBattleOrder,
 )
 from poke_env.player.player import Player
+from poke_env.player.player_options import PlayerOptions
 from poke_env.ps_client import AccountConfiguration
 from poke_env.ps_client.server_configuration import (
     LocalhostServerConfiguration,
@@ -89,9 +90,29 @@ class _EnvPlayer(Player):
     order_queue: _AsyncQueue[BattleOrder]
 
     def __init__(
-        self, *args: Any, choose_on_teampreview: bool | None = None, **kwargs: Any
+        self,
+        account_configuration: AccountConfiguration | None = None,
+        *,
+        player_options: PlayerOptions | None = None,
+        choose_on_teampreview: bool | None = None,
+        loop: asyncio.AbstractEventLoop | None = None,
+        **kwargs: Any,
     ):
-        super().__init__(*args, **kwargs)
+        if player_options is None:
+            if loop is not None:
+                kwargs["loop"] = loop
+            super().__init__(account_configuration=account_configuration, **kwargs)
+        else:
+            if loop is None or kwargs:
+                raise TypeError(
+                    "player_options requires a loop and cannot be combined with "
+                    "individual player options"
+                )
+            super().__init__(
+                **player_options.to_player_kwargs(
+                    account_configuration=account_configuration, loop=loop
+                )
+            )
         if choose_on_teampreview is None:
             self.logger.warning(
                 "choose_on_teampreview arg was not set in environment - by default, teampreview decisions will be made randomly."
@@ -248,25 +269,13 @@ class PokeEnv(ParallelEnv[str, Dict[str, Any], ActionType]):
         self.render_mode: str | None = None
         self._avatar = avatar
         self._battle_format = battle_format
-        self._log_level = log_level
-        self._save_replays = save_replays
-        self._server_configuration = server_configuration
-        self._accept_open_team_sheet = accept_open_team_sheet
-        self._start_timer_on_battle_start = start_timer_on_battle_start
-        self._start_listening = start_listening
-        self._open_timeout = open_timeout
-        self._ping_interval = ping_interval
-        self._ping_timeout = ping_timeout
         self._challenge_timeout = challenge_timeout
-        self._team = team
         self._choose_on_teampreview = choose_on_teampreview
         self._fake = fake
         self._strict = strict
         self._loop = asyncio.new_event_loop()
         Thread(target=self._loop.run_forever, daemon=True).start()
-        self.agent1 = _EnvPlayer(
-            account_configuration=account_configuration1
-            or AccountConfiguration.generate(self.__class__.__name__, rand=True),
+        self._player_options = PlayerOptions(
             avatar=avatar,
             battle_format=battle_format,
             log_level=log_level,
@@ -279,29 +288,11 @@ class PokeEnv(ParallelEnv[str, Dict[str, Any], ActionType]):
             open_timeout=open_timeout,
             ping_interval=ping_interval,
             ping_timeout=ping_timeout,
-            loop=self._loop,
             team=team,
-            choose_on_teampreview=choose_on_teampreview,
         )
-        self.agent2 = _EnvPlayer(
-            account_configuration=account_configuration2
-            or AccountConfiguration.generate(self.__class__.__name__, rand=True),
-            avatar=avatar,
-            battle_format=battle_format,
-            log_level=log_level,
-            max_concurrent_battles=1,
-            save_replays=save_replays,
-            server_configuration=server_configuration,
-            accept_open_team_sheet=accept_open_team_sheet,
-            start_timer_on_battle_start=start_timer_on_battle_start,
-            start_listening=start_listening,
-            open_timeout=open_timeout,
-            ping_interval=ping_interval,
-            ping_timeout=ping_timeout,
-            loop=self._loop,
-            team=team,
-            choose_on_teampreview=choose_on_teampreview,
-        )
+        self.agent1 = self._create_agent(account_configuration1)
+        self.agent2 = self._create_agent(account_configuration2)
+
         self.agents: List[str] = []
         self.possible_agents = [self.agent1.username, self.agent2.username]
         self.battle1: Optional[AbstractBattle] = None
@@ -313,6 +304,17 @@ class PokeEnv(ParallelEnv[str, Dict[str, Any], ActionType]):
             WeakKeyDictionary()
         )
         self._challenge_task: Optional[Future[Any]] = None
+
+    def _create_agent(
+        self, account_configuration: Optional[AccountConfiguration]
+    ) -> _EnvPlayer:
+        return _EnvPlayer(
+            account_configuration=account_configuration
+            or AccountConfiguration.generate(self.__class__.__name__, rand=True),
+            player_options=self._player_options,
+            choose_on_teampreview=self._choose_on_teampreview,
+            loop=self._loop,
+        )
 
     def __setattr__(self, name: str, value: Any):
         if name == "observation_spaces":
@@ -345,46 +347,8 @@ class PokeEnv(ParallelEnv[str, Dict[str, Any], ActionType]):
         self.__dict__.update(state)
         self._loop = asyncio.new_event_loop()
         Thread(target=self._loop.run_forever, daemon=True).start()
-        self.agent1 = _EnvPlayer(
-            account_configuration=AccountConfiguration.generate(
-                self.__class__.__name__, rand=True
-            ),
-            avatar=self._avatar,
-            battle_format=self._battle_format,
-            log_level=self._log_level,
-            max_concurrent_battles=1,
-            save_replays=self._save_replays,
-            server_configuration=self._server_configuration,
-            accept_open_team_sheet=self._accept_open_team_sheet,
-            start_timer_on_battle_start=self._start_timer_on_battle_start,
-            start_listening=self._start_listening,
-            open_timeout=self._open_timeout,
-            ping_interval=self._ping_interval,
-            ping_timeout=self._ping_timeout,
-            loop=self._loop,
-            team=self._team,
-            choose_on_teampreview=self._choose_on_teampreview,
-        )
-        self.agent2 = _EnvPlayer(
-            account_configuration=AccountConfiguration.generate(
-                self.__class__.__name__, rand=True
-            ),
-            avatar=self._avatar,
-            battle_format=self._battle_format,
-            log_level=self._log_level,
-            max_concurrent_battles=1,
-            save_replays=self._save_replays,
-            server_configuration=self._server_configuration,
-            accept_open_team_sheet=self._accept_open_team_sheet,
-            start_timer_on_battle_start=self._start_timer_on_battle_start,
-            start_listening=self._start_listening,
-            open_timeout=self._open_timeout,
-            ping_interval=self._ping_interval,
-            ping_timeout=self._ping_timeout,
-            loop=self._loop,
-            team=self._team,
-            choose_on_teampreview=self._choose_on_teampreview,
-        )
+        self.agent1 = self._create_agent(None)
+        self.agent2 = self._create_agent(None)
         self.agents = []
         old_names = self.possible_agents
         self.possible_agents = [self.agent1.username, self.agent2.username]

--- a/src/poke_env/environment/env.py
+++ b/src/poke_env/environment/env.py
@@ -41,8 +41,6 @@ from poke_env.teambuilder.teambuilder import Teambuilder
 ItemType = TypeVar("ItemType")
 ActionType = TypeVar("ActionType")
 
-_DEFAULT_POKE_ENV_PLAYER_OPTIONS = PlayerOptions(battle_format="gen9randombattle")
-
 
 class _AsyncQueue(Generic[ItemType]):
     queue: asyncio.Queue[ItemType]
@@ -182,6 +180,8 @@ class PokeEnv(ParallelEnv[str, Dict[str, Any], ActionType]):
     Base class implementing the PettingZoo API on the main thread.
     """
 
+    _default_battle_format = "gen9randombattle"
+
     def __init__(
         self,
         *,
@@ -292,9 +292,8 @@ class PokeEnv(ParallelEnv[str, Dict[str, Any], ActionType]):
             ping_timeout=ping_timeout,
             team=team,
         )
-        if (
-            player_options is not None
-            and legacy_player_options != _DEFAULT_POKE_ENV_PLAYER_OPTIONS
+        if player_options is not None and legacy_player_options != PlayerOptions(
+            battle_format=self._default_battle_format
         ):
             raise TypeError(
                 "player_options cannot be combined with non-default player options"

--- a/src/poke_env/environment/env.py
+++ b/src/poke_env/environment/env.py
@@ -41,7 +41,7 @@ from poke_env.teambuilder.teambuilder import Teambuilder
 ItemType = TypeVar("ItemType")
 ActionType = TypeVar("ActionType")
 
-_DEFAULT_POKE_ENV_PLAYER_OPTIONS = PlayerOptions(battle_format="gen8randombattle")
+_DEFAULT_POKE_ENV_PLAYER_OPTIONS = PlayerOptions(battle_format="gen9randombattle")
 
 
 class _AsyncQueue(Generic[ItemType]):

--- a/src/poke_env/environment/singles_env.py
+++ b/src/poke_env/environment/singles_env.py
@@ -14,6 +14,7 @@ from poke_env.player.battle_order import (
     SingleBattleOrder,
 )
 from poke_env.player.player import Player
+from poke_env.player.player_options import PlayerOptions
 from poke_env.ps_client import (
     AccountConfiguration,
     LocalhostServerConfiguration,
@@ -28,6 +29,7 @@ class SinglesEnv(PokeEnv[np.int64]):
         *,
         account_configuration1: Optional[AccountConfiguration] = None,
         account_configuration2: Optional[AccountConfiguration] = None,
+        player_options: Optional[PlayerOptions] = None,
         avatar: Optional[int] = None,
         battle_format: str = "gen9randombattle",
         log_level: Optional[int] = None,
@@ -50,6 +52,7 @@ class SinglesEnv(PokeEnv[np.int64]):
         super().__init__(
             account_configuration1=account_configuration1,
             account_configuration2=account_configuration2,
+            player_options=player_options,
             avatar=avatar,
             battle_format=battle_format,
             log_level=log_level,
@@ -67,7 +70,7 @@ class SinglesEnv(PokeEnv[np.int64]):
             fake=fake,
             strict=strict,
         )
-        gen = GenData.from_format(battle_format).gen
+        gen = GenData.from_format(self._player_options.battle_format).gen
         self.action_spaces: dict[str, Space[Any]] = {
             agent: Discrete(SinglesEnv.get_action_space_size(gen))
             for agent in self.possible_agents

--- a/src/poke_env/player/__init__.py
+++ b/src/poke_env/player/__init__.py
@@ -15,6 +15,7 @@ from poke_env.player.battle_order import (
     SingleBattleOrder,
 )
 from poke_env.player.player import Player
+from poke_env.player.player_options import PlayerOptions
 from poke_env.player.utils import (
     background_cross_evaluate,
     background_evaluate_player,
@@ -28,6 +29,7 @@ __all__ = [
     "POKE_LOOP",
     "PSClient",
     "Player",
+    "PlayerOptions",
     "cross_evaluate",
     "background_cross_evaluate",
     "background_evaluate_player",

--- a/src/poke_env/player/player_options.py
+++ b/src/poke_env/player/player_options.py
@@ -1,0 +1,65 @@
+"""Options shared by player and environment configuration."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Any, Optional, Union
+
+from poke_env.ps_client.account_configuration import AccountConfiguration
+from poke_env.ps_client.server_configuration import (
+    LocalhostServerConfiguration,
+    ServerConfiguration,
+)
+from poke_env.teambuilder.teambuilder import Teambuilder
+
+
+@dataclass(frozen=True)
+class PlayerOptions:
+    """Configuration shared by players created for the same environment.
+
+    Account configuration and the event loop are supplied by the owner creating a
+    player. They are intentionally not stored here because environments use one set
+    of options for two accounts and recreate their loop when unpickled.
+    """
+
+    avatar: Optional[Union[str, int]] = None
+    battle_format: str = "gen9randombattle"
+    log_level: Optional[int] = None
+    max_concurrent_battles: int = 1
+    accept_open_team_sheet: Optional[bool] = False
+    save_replays: Union[bool, str] = False
+    server_configuration: Optional[ServerConfiguration] = LocalhostServerConfiguration
+    start_timer_on_battle_start: bool = False
+    start_listening: bool = True
+    open_timeout: Optional[float] = 10.0
+    ping_interval: Optional[float] = 20.0
+    ping_timeout: Optional[float] = 20.0
+    team: Optional[Union[str, Teambuilder]] = None
+    strict_battle_tracking: bool = False
+
+    def to_player_kwargs(
+        self,
+        *,
+        account_configuration: Optional[AccountConfiguration],
+        loop: asyncio.AbstractEventLoop,
+    ) -> dict[str, Any]:
+        """Return keyword arguments for constructing a :class:`Player`."""
+        return {
+            "account_configuration": account_configuration,
+            "avatar": self.avatar,
+            "battle_format": self.battle_format,
+            "log_level": self.log_level,
+            "max_concurrent_battles": self.max_concurrent_battles,
+            "accept_open_team_sheet": self.accept_open_team_sheet,
+            "save_replays": self.save_replays,
+            "server_configuration": self.server_configuration,
+            "start_timer_on_battle_start": self.start_timer_on_battle_start,
+            "start_listening": self.start_listening,
+            "open_timeout": self.open_timeout,
+            "ping_interval": self.ping_interval,
+            "ping_timeout": self.ping_timeout,
+            "loop": loop,
+            "team": self.team,
+            "strict_battle_tracking": self.strict_battle_tracking,
+        }

--- a/src/poke_env/player/player_options.py
+++ b/src/poke_env/player/player_options.py
@@ -18,6 +18,8 @@ from poke_env.teambuilder.teambuilder import Teambuilder
 class PlayerOptions:
     """Configuration shared by players created for the same environment.
 
+    Pass an instance through the ``player_options`` argument of ``PokeEnv``,
+    ``SinglesEnv``, or ``DoublesEnv`` to configure both environment agents.
     Account configuration and the event loop are supplied by the owner creating a
     player. They are intentionally not stored here because environments use one set
     of options for two accounts and recreate their loop when unpickled.

--- a/unit_tests/player/test_env.py
+++ b/unit_tests/player/test_env.py
@@ -75,6 +75,14 @@ def test_pickle_unpickle():
     assert len(restored.action_spaces) == 2
 
 
+def test_environment_defaults_to_gen9_random_battle():
+    env = CustomEnv(start_listening=False)
+
+    assert env._battle_format == "gen9randombattle"
+    assert env.agent1.format == "gen9randombattle"
+    assert env.agent2.format == "gen9randombattle"
+
+
 def test_player_options_build_player_kwargs():
     options = PlayerOptions(
         avatar="avatar",

--- a/unit_tests/player/test_env.py
+++ b/unit_tests/player/test_env.py
@@ -28,6 +28,7 @@ from poke_env.player import (
     DoubleBattleOrder,
     ForfeitBattleOrder,
     Player,
+    PlayerOptions,
     SingleBattleOrder,
 )
 from poke_env.ps_client import AccountConfiguration, ServerConfiguration
@@ -62,6 +63,7 @@ def test_pickle_unpickle():
 
     assert isinstance(restored, CustomEnv)
     assert restored._battle_format == env._battle_format
+    assert restored._player_options == env._player_options
     assert restored._strict == env._strict
     assert restored._fake == env._fake
     assert restored.agent1 is not None
@@ -71,6 +73,48 @@ def test_pickle_unpickle():
     assert len(restored.possible_agents) == 2
     assert len(restored.observation_spaces) == 2
     assert len(restored.action_spaces) == 2
+
+
+def test_player_options_build_player_kwargs():
+    options = PlayerOptions(
+        avatar="avatar",
+        battle_format="gen9ou",
+        log_level=25,
+        max_concurrent_battles=3,
+        accept_open_team_sheet=True,
+        save_replays=True,
+        server_configuration=server_configuration,
+        start_timer_on_battle_start=True,
+        start_listening=False,
+        open_timeout=None,
+        ping_interval=None,
+        ping_timeout=None,
+        team="team",
+        strict_battle_tracking=True,
+    )
+
+    kwargs = options.to_player_kwargs(
+        account_configuration=account_configuration1, loop=POKE_LOOP
+    )
+
+    assert kwargs == {
+        "account_configuration": account_configuration1,
+        "avatar": "avatar",
+        "battle_format": "gen9ou",
+        "log_level": 25,
+        "max_concurrent_battles": 3,
+        "accept_open_team_sheet": True,
+        "save_replays": True,
+        "server_configuration": server_configuration,
+        "start_timer_on_battle_start": True,
+        "start_listening": False,
+        "open_timeout": None,
+        "ping_interval": None,
+        "ping_timeout": None,
+        "loop": POKE_LOOP,
+        "team": "team",
+        "strict_battle_tracking": True,
+    }
 
 
 def test_init_queue():

--- a/unit_tests/player/test_env.py
+++ b/unit_tests/player/test_env.py
@@ -117,6 +117,39 @@ def test_player_options_build_player_kwargs():
     }
 
 
+def test_player_options_configure_environment():
+    options = PlayerOptions(
+        battle_format="gen9ou",
+        max_concurrent_battles=3,
+        accept_open_team_sheet=True,
+        server_configuration=server_configuration,
+        start_listening=False,
+    )
+    env = CustomEnv(player_options=options)
+
+    assert env._player_options == options
+    assert env._battle_format == "gen9ou"
+    assert env.agent1.format == "gen9ou"
+    assert env.agent1._max_concurrent_battles == 3
+    assert env.agent1.accept_open_team_sheet
+
+
+@pytest.mark.parametrize("environment_class", [SinglesEnv, DoublesEnv])
+def test_player_options_are_accepted_by_concrete_environments(environment_class):
+    options = PlayerOptions(start_listening=False, battle_format="gen9ou")
+    env = environment_class(player_options=options)
+
+    assert env._player_options == options
+    assert env._battle_format == "gen9ou"
+
+
+def test_player_options_cannot_be_combined_with_legacy_options():
+    with pytest.raises(
+        TypeError, match="player_options cannot be combined with non-default"
+    ):
+        CustomEnv(player_options=PlayerOptions(), team="team")
+
+
 def test_init_queue():
     q = _AsyncQueue(POKE_LOOP)
     assert isinstance(q, _AsyncQueue)


### PR DESCRIPTION
Add a shared `PlayerOptions` configuration so PokeEnv, SinglesEnv, and DoublesEnv can construct both agents consistently without duplicating player configuration.

The environments now accept `player_options=` directly, use it when deriving action-space formats, and reject non-default legacy player arguments when both APIs are mixed. Account configurations and environment-only settings remain separate. The branch is rebased on `master`, whose environment defaults use Gen 9 formats (`gen9randombattle` and `gen9randomdoublesbattle`).

Validation:
- `uv run pytest unit_tests -q` (340 passed)
- `uv run mypy src`
- `uv run black --check src/ unit_tests/ integration_tests/`
- `uv run isort --check-only .`
- `uv run flake8 src/ unit_tests/ integration_tests/`
- `uv run python -m sphinx -b html -W docs/source docs/_build/html`